### PR TITLE
Dependency updates and minor tweaks to fragment executor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.29-alpha'
+        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.31-alpha'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/enro-core/build.gradle
+++ b/enro-core/build.gradle
@@ -7,14 +7,14 @@ publishAndroidModule("dev.enro", "enro-core")
 dependencies {
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'androidx.fragment:fragment-ktx:1.2.5'
-    implementation 'androidx.activity:activity:1.1.0'
+    implementation 'androidx.fragment:fragment-ktx:1.3.1'
+    implementation 'androidx.activity:activity:1.2.1'
 
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.1'
 
-    compileOnly 'com.google.dagger:hilt-android:2.29-alpha'
-    kapt 'androidx.hilt:hilt-compiler:1.0.0-alpha02'
-    kapt 'com.google.dagger:hilt-android-compiler:2.29-alpha'
+    compileOnly 'com.google.dagger:hilt-android:2.30.1-alpha'
+    kapt 'androidx.hilt:hilt-compiler:1.0.0-beta01'
+    kapt 'com.google.dagger:hilt-android-compiler:2.30.1-alpha'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/enro-core/build.gradle
+++ b/enro-core/build.gradle
@@ -12,9 +12,9 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.1'
 
-    compileOnly 'com.google.dagger:hilt-android:2.30.1-alpha'
+    compileOnly 'com.google.dagger:hilt-android:2.31-alpha'
     kapt 'androidx.hilt:hilt-compiler:1.0.0-beta01'
-    kapt 'com.google.dagger:hilt-android-compiler:2.30.1-alpha'
+    kapt 'com.google.dagger:hilt-android-compiler:2.31-alpha'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/enro-core/src/main/java/dev/enro/core/NavigationAnimations.kt
+++ b/enro-core/src/main/java/dev/enro/core/NavigationAnimations.kt
@@ -1,13 +1,12 @@
 package dev.enro.core
 
 import android.content.res.Resources
-import android.os.Parcel
 import android.os.Parcelable
-import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentActivity
-import kotlinx.android.parcel.Parcelize
 import dev.enro.core.controller.navigationController
+import dev.enro.core.fragment.internal.AbstractSingleFragmentActivity
+import dev.enro.core.fragment.internal.SingleFragmentKey
 import dev.enro.core.internal.getAttributeResourceId
+import kotlinx.android.parcel.Parcelize
 
 sealed class AnimationPair : Parcelable{
     abstract val enter: Int
@@ -67,6 +66,13 @@ fun animationsFor(
 ): AnimationPair.Resource {
     if (navigationInstruction is NavigationInstruction.Open && navigationInstruction.children.isNotEmpty()) {
         return AnimationPair.Resource(0, 0)
+    }
+
+    if(navigationInstruction is NavigationInstruction.Open && context.contextReference is AbstractSingleFragmentActivity) {
+        val singleFragmentKey = context.getNavigationHandleViewModel().key as SingleFragmentKey
+        if(navigationInstruction.instructionId == singleFragmentKey.instruction.instructionId) {
+            return AnimationPair.Resource(0, 0)
+        }
     }
 
     return when (navigationInstruction) {

--- a/enro-core/src/main/java/dev/enro/core/fragment/DefaultFragmentExecutor.kt
+++ b/enro-core/src/main/java/dev/enro/core/fragment/DefaultFragmentExecutor.kt
@@ -72,7 +72,7 @@ object DefaultFragmentExecutor : NavigationExecutor<Any, Fragment, NavigationKey
 
         val animations = animationsFor(fromContext, instruction)
 
-        host.fragmentManager.commitNow {
+        host.fragmentManager.commit {
             setCustomAnimations(animations.enter, animations.exit)
 
             if(fromContext.contextReference is DialogFragment && instruction.navigationDirection == NavigationDirection.REPLACE) {
@@ -107,7 +107,7 @@ object DefaultFragmentExecutor : NavigationExecutor<Any, Fragment, NavigationKey
         val animations = animationsFor(context, NavigationInstruction.Close)
         val sameFragmentManagers = previousFragment?.parentFragmentManager == context.fragment.parentFragmentManager
 
-        context.fragment.parentFragmentManager.commitNow {
+        context.fragment.parentFragmentManager.commit {
             setCustomAnimations(animations.enter, animations.exit)
             remove(context.fragment)
 
@@ -121,7 +121,7 @@ object DefaultFragmentExecutor : NavigationExecutor<Any, Fragment, NavigationKey
         }
 
         if(previousFragment != null && !sameFragmentManagers) {
-            previousFragment.parentFragmentManager.commitNow {
+            previousFragment.parentFragmentManager.commit {
                 setPrimaryNavigationFragment(previousFragment)
             }
         }

--- a/enro-core/src/main/java/dev/enro/core/fragment/internal/SingleFragmentActivity.kt
+++ b/enro-core/src/main/java/dev/enro/core/fragment/internal/SingleFragmentActivity.kt
@@ -3,10 +3,10 @@ package dev.enro.core.fragment.internal
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.android.parcel.Parcelize
 import dev.enro.core.NavigationInstruction
 import dev.enro.core.NavigationKey
 import dev.enro.core.navigationHandle
+import kotlinx.android.parcel.Parcelize
 
 @Parcelize
 internal data class SingleFragmentKey(
@@ -19,7 +19,6 @@ internal abstract class AbstractSingleFragmentActivity : AppCompatActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        overridePendingTransition(0, 0)
         super.onCreate(savedInstanceState)
         if(savedInstanceState == null) {
             handle.executeInstruction(handle.key.instruction)

--- a/enro-core/src/main/java/dev/enro/core/result/EnroResultExtensions.kt
+++ b/enro-core/src/main/java/dev/enro/core/result/EnroResultExtensions.kt
@@ -13,9 +13,9 @@ import dev.enro.core.result.internal.ResultChannelImpl
 import kotlin.properties.ReadOnlyProperty
 
 
-fun <T: Any> NavigationHandle.closeWithResult(result: T) {
+fun <T : Any> NavigationHandle.closeWithResult(result: T) {
     val resultId = ResultChannelImpl.getResultId(this)
-    if(resultId != null) {
+    if (resultId != null) {
         EnroResult.from(controller).addPendingResult(
             PendingResult(
                 resultChannelId = resultId,
@@ -27,9 +27,9 @@ fun <T: Any> NavigationHandle.closeWithResult(result: T) {
     close()
 }
 
-fun <T: Any> TypedNavigationHandle<out NavigationKey.WithResult<T>>.closeWithResult(result: T) {
+fun <T : Any> TypedNavigationHandle<out NavigationKey.WithResult<T>>.closeWithResult(result: T) {
     val resultId = ResultChannelImpl.getResultId(this)
-    if(resultId != null) {
+    if (resultId != null) {
         EnroResult.from(controller).addPendingResult(
             PendingResult(
                 resultChannelId = resultId,
@@ -53,7 +53,7 @@ inline fun <reified T : Any> ViewModel.registerForNavigationResult(
 
 inline fun <reified T : Any> FragmentActivity.registerForNavigationResult(
     noinline onResult: (T) -> Unit
-): ReadOnlyProperty<FragmentActivity, EnroResultChannel<T>>  =
+): ReadOnlyProperty<FragmentActivity, EnroResultChannel<T>> =
     LazyResultChannelProperty(
         owner = this,
         resultType = T::class.java,
@@ -62,7 +62,7 @@ inline fun <reified T : Any> FragmentActivity.registerForNavigationResult(
 
 inline fun <reified T : Any> Fragment.registerForNavigationResult(
     noinline onResult: (T) -> Unit
-): ReadOnlyProperty<Fragment, EnroResultChannel<T>>  =
+): ReadOnlyProperty<Fragment, EnroResultChannel<T>> =
     LazyResultChannelProperty(
         owner = this,
         resultType = T::class.java,

--- a/enro-core/src/main/java/dev/enro/core/result/internal/LazyResultChannelProperty.kt
+++ b/enro-core/src/main/java/dev/enro/core/result/internal/LazyResultChannelProperty.kt
@@ -22,16 +22,16 @@ internal class LazyResultChannelProperty<T>(
 
     init {
         val handle = when (owner) {
-                is FragmentActivity -> lazy { owner.getNavigationHandle() }
-                is Fragment ->lazy { owner.getNavigationHandle() }
-                is NavigationHandle -> lazy { owner as NavigationHandle }
-                else -> throw IllegalArgumentException("Owner must be a Fragment, FragmentActivity, or NavigationHandle")
-            }
+            is FragmentActivity -> lazy { owner.getNavigationHandle() }
+            is Fragment -> lazy { owner.getNavigationHandle() }
+            is NavigationHandle -> lazy { owner as NavigationHandle }
+            else -> throw IllegalArgumentException("Owner must be a Fragment, FragmentActivity, or NavigationHandle")
+        }
         val lifecycle = owner as LifecycleOwner
 
         lifecycle.lifecycle.addObserver(object : LifecycleEventObserver {
             override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
-                if(event != Lifecycle.Event.ON_START)  return
+                if (event != Lifecycle.Event.ON_START) return
                 lifecycle.lifecycle.removeObserver(this)
 
                 resultChannel = ResultChannelImpl(
@@ -42,13 +42,13 @@ internal class LazyResultChannelProperty<T>(
             }
         })
 
-        lifecycle.lifecycle.addObserver(object: LifecycleEventObserver {
+        lifecycle.lifecycle.addObserver(object : LifecycleEventObserver {
             private var enroResult: EnroResult? = null
             override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
-                if(event == Lifecycle.Event.ON_STOP) {
+                if (event == Lifecycle.Event.ON_STOP) {
                     enroResult = EnroResult.from(handle.value.controller)
                 }
-                if(event == Lifecycle.Event.ON_DESTROY) {
+                if (event == Lifecycle.Event.ON_DESTROY) {
                     enroResult?.deregisterChannel(resultChannel)
                     enroResult = null
                 }

--- a/enro-core/src/main/res/anim/enro_test_exit_animation.xml
+++ b/enro-core/src/main/res/anim/enro_test_exit_animation.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
   Copyright 2019 The Android Open Source Project
-
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
-
        http://www.apache.org/licenses/LICENSE-2.0
-
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,8 +14,8 @@
 <set xmlns:android="http://schemas.android.com/apk/res/android"
     android:shareInterpolator="false">
     <alpha
-        android:fromAlpha="0.0"
-        android:toAlpha="1.0"
+        android:fromAlpha="1.0"
+        android:toAlpha="0.0"
         android:fillEnabled="true"
         android:fillBefore="true"
         android:fillAfter="true"

--- a/enro-masterdetail/build.gradle
+++ b/enro-masterdetail/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.appcompat:appcompat:1.2.0'
 
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.1'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/enro-multistack/build.gradle
+++ b/enro-multistack/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.appcompat:appcompat:1.2.0'
 
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.1'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/enro/build.gradle
+++ b/enro/build.gradle
@@ -26,8 +26,8 @@ dependencies {
 
     androidTestImplementation 'androidx.core:core-ktx:1.3.2'
     androidTestImplementation 'androidx.appcompat:appcompat:1.2.0'
-    androidTestImplementation 'androidx.fragment:fragment-ktx:1.2.5'
-    androidTestImplementation 'androidx.activity:activity:1.1.0'
+    androidTestImplementation 'androidx.fragment:fragment-ktx:1.3.1'
+    androidTestImplementation 'androidx.activity:activity:1.2.1'
 
     androidTestImplementation "androidx.fragment:fragment-testing:1.3.1"
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -37,16 +37,16 @@ dependencies {
     kapt project(":enro-processor")
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.2.0'
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.core:core-ktx:1.3.2'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'androidx.fragment:fragment-ktx:1.2.4'
-    implementation 'androidx.activity:activity-ktx:1.1.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation 'androidx.fragment:fragment-ktx:1.3.1'
+    implementation 'androidx.activity:activity-ktx:1.2.1'
 
-    implementation 'com.google.android.material:material:1.2.0-alpha06'
+    implementation 'com.google.android.material:material:1.4.0-alpha01'
 
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    testImplementation 'junit:junit:4.13.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 }

--- a/modularised-example/app/build.gradle
+++ b/modularised-example/app/build.gradle
@@ -56,10 +56,10 @@ dependencies {
     implementation 'androidx.fragment:fragment-ktx:1.3.1'
     implementation 'androidx.activity:activity-ktx:1.2.1'
 
-    implementation 'com.google.dagger:hilt-android:2.30.1-alpha'
+    implementation 'com.google.dagger:hilt-android:2.31-alpha'
     implementation 'androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha03'
     kapt 'androidx.hilt:hilt-compiler:1.0.0-beta01'
-    kapt 'com.google.dagger:hilt-android-compiler:2.30.1-alpha'
+    kapt 'com.google.dagger:hilt-android-compiler:2.31-alpha'
 
     implementation 'com.google.android.material:material:1.4.0-alpha01'
     testImplementation 'junit:junit:4.13.1'

--- a/modularised-example/app/build.gradle
+++ b/modularised-example/app/build.gradle
@@ -13,6 +13,7 @@ android {
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"
+        multiDexEnabled true
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -48,22 +49,22 @@ dependencies {
     implementation project(':modularised-example:feature:user')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.3.1'
+    implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.0'
-    implementation 'androidx.fragment:fragment-ktx:1.2.5'
-    implementation 'androidx.activity:activity-ktx:1.1.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation 'androidx.fragment:fragment-ktx:1.3.1'
+    implementation 'androidx.activity:activity-ktx:1.2.1'
 
-    implementation 'com.google.dagger:hilt-android:2.29-alpha'
-    implementation 'androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha02'
-    kapt 'androidx.hilt:hilt-compiler:1.0.0-alpha02'
-    kapt 'com.google.dagger:hilt-android-compiler:2.29-alpha'
+    implementation 'com.google.dagger:hilt-android:2.30.1-alpha'
+    implementation 'androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha03'
+    kapt 'androidx.hilt:hilt-compiler:1.0.0-beta01'
+    kapt 'com.google.dagger:hilt-android-compiler:2.30.1-alpha'
 
-    implementation 'com.google.android.material:material:1.3.0-alpha02'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    implementation 'com.google.android.material:material:1.4.0-alpha01'
+    testImplementation 'junit:junit:4.13.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 
 }
 kapt {

--- a/modularised-example/app/src/main/AndroidManifest.xml
+++ b/modularised-example/app/src/main/AndroidManifest.xml
@@ -17,11 +17,11 @@
             </intent-filter>
         </activity>
         <activity android:name="dev.enro.example.login.LoginActivity"/>
-        <activity android:name=".dashboard.DashboardActivity" />
-        <activity android:name=".detail.DetailActivity" />
-        <activity android:name=".search.SearchActivity" />
-        <activity android:name=".multistack.MultiStackActivity" />
-        <activity android:name=".masterdetail.MasterDetailActivity" />
+        <activity android:name="dev.enro.example.dashboard.DashboardActivity" />
+        <activity android:name="dev.enro.example.detail.DetailActivity" />
+        <activity android:name="dev.enro.example.search.SearchActivity" />
+        <activity android:name="dev.enro.example.multistack.MultiStackActivity" />
+        <activity android:name="dev.enro.example.masterdetail.MasterDetailActivity" />
 
     </application>
 

--- a/modularised-example/app/src/main/java/dev/enro/example/modularised/ExampleApplication.kt
+++ b/modularised-example/app/src/main/java/dev/enro/example/modularised/ExampleApplication.kt
@@ -20,7 +20,7 @@ class ExampleApplication : Application(), NavigationApplication {
 
         override<MainActivity, Any> {
             animation {
-                AnimationPair.Resource(R.anim.fragment_fade_enter, R.anim.enro_no_op_animation)
+                AnimationPair.Resource(android.R.anim.fade_in, R.anim.enro_no_op_animation)
             }
         }
     }

--- a/modularised-example/app/src/main/java/dev/enro/example/modularised/MainActivity.kt
+++ b/modularised-example/app/src/main/java/dev/enro/example/modularised/MainActivity.kt
@@ -5,9 +5,9 @@ import android.animation.AnimatorListenerAdapter
 import android.view.View
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.enro.annotations.NavigationDestination
 import dev.enro.core.*
 import dev.enro.core.synthetic.SyntheticDestination
@@ -16,16 +16,18 @@ import dev.enro.example.core.navigation.DashboardKey
 import dev.enro.example.core.navigation.LaunchKey
 import dev.enro.example.core.navigation.LoginKey
 import kotlinx.android.parcel.Parcelize
+import javax.inject.Inject
 
 @Parcelize
 class MainKey : NavigationKey
 
-class HiltViewModel @ViewModelInject constructor(): ViewModel()
+@HiltViewModel
+class ExampleHiltViewModel @Inject constructor(): ViewModel()
 
 @AndroidEntryPoint
 @NavigationDestination(MainKey::class)
 class MainActivity : AppCompatActivity() {
-    private val hiltViewModel by viewModels<HiltViewModel>()
+    private val hiltViewModel by viewModels<ExampleHiltViewModel>()
     private val navigation by navigationHandle<MainKey> {
         defaultKey(MainKey())
     }

--- a/modularised-example/core/build.gradle
+++ b/modularised-example/core/build.gradle
@@ -6,10 +6,10 @@ dependencies {
     kapt project(":enro-processor")
 
     api "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    api 'androidx.core:core-ktx:1.2.0'
-    api 'androidx.appcompat:appcompat:1.1.0'
+    api 'androidx.core:core-ktx:1.3.2'
+    api 'androidx.appcompat:appcompat:1.2.0'
     api 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-    api 'androidx.constraintlayout:constraintlayout:1.1.3'
-    api 'androidx.fragment:fragment-ktx:1.2.4'
-    api 'androidx.activity:activity-ktx:1.1.0'
+    api 'androidx.constraintlayout:constraintlayout:2.0.4'
+    api 'androidx.fragment:fragment-ktx:1.3.1'
+    api 'androidx.activity:activity-ktx:1.2.1'
 }

--- a/modularised-example/feature/list/build.gradle
+++ b/modularised-example/feature/list/build.gradle
@@ -6,10 +6,10 @@ dependencies {
     implementation project(":modularised-example:core")
     implementation project(":enro")
 
-    implementation 'com.google.dagger:hilt-android:2.30.1-alpha'
+    implementation 'com.google.dagger:hilt-android:2.31-alpha'
     implementation 'androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha03'
     kapt 'androidx.hilt:hilt-compiler:1.0.0-beta01'
-    kapt 'com.google.dagger:hilt-android-compiler:2.30.1-alpha'
+    kapt 'com.google.dagger:hilt-android-compiler:2.31-alpha'
 
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     kapt project(":enro-processor")

--- a/modularised-example/feature/list/build.gradle
+++ b/modularised-example/feature/list/build.gradle
@@ -6,10 +6,10 @@ dependencies {
     implementation project(":modularised-example:core")
     implementation project(":enro")
 
-    implementation 'com.google.dagger:hilt-android:2.29-alpha'
-    implementation 'androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha02'
-    kapt 'androidx.hilt:hilt-compiler:1.0.0-alpha02'
-    kapt 'com.google.dagger:hilt-android-compiler:2.29-alpha'
+    implementation 'com.google.dagger:hilt-android:2.30.1-alpha'
+    implementation 'androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha03'
+    kapt 'androidx.hilt:hilt-compiler:1.0.0-beta01'
+    kapt 'com.google.dagger:hilt-android-compiler:2.30.1-alpha'
 
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     kapt project(":enro-processor")

--- a/modularised-example/feature/list/src/main/java/dev/enro/example/list/List.kt
+++ b/modularised-example/feature/list/src/main/java/dev/enro/example/list/List.kt
@@ -7,28 +7,28 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.fragment.app.Fragment
-import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.observe
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import dagger.hilt.android.AndroidEntryPoint
-import dagger.hilt.android.scopes.ActivityRetainedScoped
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.scopes.ViewModelScoped
 import dev.enro.annotations.NavigationDestination
+import dev.enro.core.result.closeWithResult
+import dev.enro.core.result.registerForNavigationResult
 import dev.enro.example.core.base.SingleStateViewModel
 import dev.enro.example.core.data.SimpleData
 import dev.enro.example.core.data.SimpleDataRepository
 import dev.enro.example.core.navigation.DetailKey
 import dev.enro.example.core.navigation.ListFilterType
 import dev.enro.example.core.navigation.ListKey
-import dev.enro.core.result.closeWithResult
-import dev.enro.core.result.registerForNavigationResult
 import dev.enro.viewmodel.enroViewModels
 import dev.enro.viewmodel.navigationHandle
 import javax.inject.Inject
 
-@ActivityRetainedScoped
+@ViewModelScoped
 class ExampleHiltDependency @Inject constructor() {
     fun doSomething() {
         Log.d("ExampleHiltDependency", "Something was done!")
@@ -69,7 +69,8 @@ data class ListState(
     val result: Boolean = true
 )
 
-class ListViewModel @ViewModelInject constructor(
+@HiltViewModel
+class ListViewModel @Inject constructor(
     private val hiltDependency: ExampleHiltDependency
 ) : SingleStateViewModel<ListState>() {
 

--- a/modularised-example/feature/masterdetail/build.gradle
+++ b/modularised-example/feature/masterdetail/build.gradle
@@ -6,10 +6,10 @@ dependencies {
     implementation project(":modularised-example:core")
     implementation project(":enro")
 
-    implementation 'com.google.dagger:hilt-android:2.30.1-alpha'
+    implementation 'com.google.dagger:hilt-android:2.31-alpha'
     implementation 'androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha03'
     kapt 'androidx.hilt:hilt-compiler:1.0.0-beta01'
-    kapt 'com.google.dagger:hilt-android-compiler:2.30.1-alpha'
+    kapt 'com.google.dagger:hilt-android-compiler:2.31-alpha'
 
     kapt project(":enro-processor")
 }

--- a/modularised-example/feature/masterdetail/build.gradle
+++ b/modularised-example/feature/masterdetail/build.gradle
@@ -6,10 +6,10 @@ dependencies {
     implementation project(":modularised-example:core")
     implementation project(":enro")
 
-    implementation 'com.google.dagger:hilt-android:2.29-alpha'
-    implementation 'androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha02'
-    kapt 'androidx.hilt:hilt-compiler:1.0.0-alpha02'
-    kapt 'com.google.dagger:hilt-android-compiler:2.29-alpha'
+    implementation 'com.google.dagger:hilt-android:2.30.1-alpha'
+    implementation 'androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha03'
+    kapt 'androidx.hilt:hilt-compiler:1.0.0-beta01'
+    kapt 'com.google.dagger:hilt-android-compiler:2.30.1-alpha'
 
     kapt project(":enro-processor")
 }


### PR DESCRIPTION
It appears that the use of commitNow in the DefaultFragmentExecutor can cause some issues when navigation occurs quickly (which is required for the "forward navigation results" changes that are coming soon)