### PR TITLE
Allow testing against non-navigation applications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         script: ./gradlew :enro:connectedCheck
 
     - name: Run Modularised Example Tests
+      uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: 29
         script: ./gradlew :modularised-example:app:testDebugUnitTest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,19 @@ on:
       - main
 jobs:
   run-ui-tests:
-    name: Run UI Tests
+    name: Run Tests
     runs-on: macos-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Run
+    - name: Run Enro UI Tests
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: 29
         script: ./gradlew :enro:connectedCheck
+
+    - name: Run Modularised Example Tests
+      with:
+        api-level: 29
+        script: ./gradlew :modularised-example:app:testDebugUnitTest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Run UI Tests
+      - name: Run Enro UI Tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29
           script: ./gradlew :enro:connectedCheck
+
+      - name: Run Modularised Example Tests
+        with:
+          api-level: 29
+          script: ./gradlew :modularised-example:app:testDebugUnitTest
 
       - name: Install gpg secret key
         run: cat <(echo -e "${{ secrets.PUBLISH_SIGNING_KEY_LITERAL }}") | gpg --batch --import

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
           script: ./gradlew :enro:connectedCheck
 
       - name: Run Modularised Example Tests
+        uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29
           script: ./gradlew :modularised-example:app:testDebugUnitTest

--- a/enro-core/src/main/java/dev/enro/core/controller/NavigationApplication.kt
+++ b/enro-core/src/main/java/dev/enro/core/controller/NavigationApplication.kt
@@ -1,10 +1,5 @@
 package dev.enro.core.controller
 
-import android.app.Application
-import dev.enro.core.controller.NavigationController
-
 interface NavigationApplication {
     val navigationController: NavigationController
 }
-
-val Application.navigationController get() = (this as NavigationApplication).navigationController

--- a/enro-core/src/main/java/dev/enro/core/controller/NavigationController.kt
+++ b/enro-core/src/main/java/dev/enro/core/controller/NavigationController.kt
@@ -94,6 +94,28 @@ class NavigationController internal constructor(
         if (navigationApplication !is Application)
             throw IllegalArgumentException("A NavigationApplication must extend android.app.Application")
 
+        navigationControllerBindings[navigationApplication] = this
         contextController.install(navigationApplication)
     }
+
+    internal fun installForTest(application: Application) {
+        navigationControllerBindings[application] = this
+        contextController.install(application)
+    }
+
+    internal fun uninstall(application: Application) {
+        navigationControllerBindings.remove(application)
+        contextController.uninstall(application)
+    }
+
+    companion object {
+        internal val navigationControllerBindings = mutableMapOf<Application, NavigationController>()
+    }
+}
+
+val Application.navigationController: NavigationController get() {
+    if(this is NavigationApplication) return navigationController
+    val bound = NavigationController.navigationControllerBindings[this]
+    if(bound != null) return bound
+    throw IllegalStateException("Application is not a NavigationApplication, and has no attached NavigationController ")
 }

--- a/enro-core/src/main/java/dev/enro/core/controller/NavigationController.kt
+++ b/enro-core/src/main/java/dev/enro/core/controller/NavigationController.kt
@@ -98,18 +98,20 @@ class NavigationController internal constructor(
         contextController.install(navigationApplication)
     }
 
-    internal fun installForTest(application: Application) {
+    private fun installForTest(application: Application) {
         navigationControllerBindings[application] = this
         contextController.install(application)
     }
 
-    internal fun uninstall(application: Application) {
+    private fun uninstall(application: Application) {
         navigationControllerBindings.remove(application)
         contextController.uninstall(application)
     }
 
     companion object {
         internal val navigationControllerBindings = mutableMapOf<Application, NavigationController>()
+
+        private fun getBoundApplicationForTest(application: Application) = navigationControllerBindings[application]
     }
 }
 

--- a/enro-core/src/main/java/dev/enro/core/controller/lifecycle/NavigationContextLifecycleCallbacks.kt
+++ b/enro-core/src/main/java/dev/enro/core/controller/lifecycle/NavigationContextLifecycleCallbacks.kt
@@ -2,17 +2,13 @@ package dev.enro.core.controller.lifecycle
 
 import android.app.Activity
 import android.app.Application
-import android.content.Context
 import android.os.Bundle
-import android.util.Log
-import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.LifecycleOwner
-import dev.enro.core.*
+import dev.enro.core.ActivityContext
+import dev.enro.core.FragmentContext
+import dev.enro.core.navigationContext
 
 internal class NavigationContextLifecycleCallbacks (
     private val lifecycleController: NavigationLifecycleController
@@ -22,6 +18,10 @@ internal class NavigationContextLifecycleCallbacks (
     private val activityCallbacks = ActivityCallbacks()
 
     fun install(application: Application) {
+        application.registerActivityLifecycleCallbacks(activityCallbacks)
+    }
+
+    internal fun uninstall(application: Application) {
         application.registerActivityLifecycleCallbacks(activityCallbacks)
     }
 

--- a/enro-core/src/main/java/dev/enro/core/controller/lifecycle/NavigationLifecycleController.kt
+++ b/enro-core/src/main/java/dev/enro/core/controller/lifecycle/NavigationLifecycleController.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelStoreOwner
 import dev.enro.core.*
-import dev.enro.core.controller.NavigationApplication
 import dev.enro.core.controller.container.ExecutorContainer
 import dev.enro.core.controller.container.PluginContainer
 import dev.enro.core.internal.NoNavigationKey
@@ -24,10 +23,11 @@ internal class NavigationLifecycleController(
     private val callbacks = NavigationContextLifecycleCallbacks(this)
 
     fun install(application: Application) {
-        application as? NavigationApplication
-            ?: throw IllegalStateException("Application MUST be a NavigationApplication")
-
         callbacks.install(application)
+    }
+
+    internal fun uninstall(application: Application) {
+        callbacks.uninstall(application)
     }
 
     fun onContextCreated(context: NavigationContext<*>, savedInstanceState: Bundle?) {

--- a/enro-test/src/main/java/dev/enro/test/EnroTest.kt
+++ b/enro-test/src/main/java/dev/enro/test/EnroTest.kt
@@ -15,7 +15,7 @@ import java.lang.reflect.Field
 object EnroTest {
     private val generatedBindings: List<NavigationComponentBuilderCommand> by lazy {
         val isDexClassLoader = Thread.currentThread().contextClassLoader::class.java is BaseDexClassLoader
-        val classes = if(isDexClassLoader) getGeneratedClasses() else getGeneratedClassesFromDexFile()
+        val classes = if(isDexClassLoader) getGeneratedClassesFromDexFile() else getGeneratedClasses()
 
         classes
             .filter {

--- a/enro-test/src/main/java/dev/enro/test/EnroTest.kt
+++ b/enro-test/src/main/java/dev/enro/test/EnroTest.kt
@@ -8,6 +8,7 @@ import dev.enro.core.controller.NavigationApplication
 import dev.enro.core.controller.NavigationComponentBuilder
 import dev.enro.core.controller.NavigationComponentBuilderCommand
 import dev.enro.core.controller.NavigationController
+import dev.enro.core.plugins.EnroHilt
 import dev.enro.core.plugins.EnroLogger
 import java.io.File
 import java.lang.reflect.Field
@@ -34,6 +35,11 @@ object EnroTest {
         NavigationComponentBuilder()
             .apply { generatedBindings.forEach { it.execute(this) } }
             .apply {
+                runCatching {
+                    if(Class.forName("dagger.hilt.internal.GeneratedComponentManager").isAssignableFrom(application::class.java)) {
+                        plugin(EnroHilt())
+                    }
+                }
                 plugin(EnroLogger())
             }
             .callPrivate<NavigationController>("build")

--- a/enro-test/src/main/java/dev/enro/test/EnroTest.kt
+++ b/enro-test/src/main/java/dev/enro/test/EnroTest.kt
@@ -2,10 +2,29 @@ package dev.enro.test
 
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
+import dalvik.system.BaseDexClassLoader
+import dalvik.system.DexFile
 import dev.enro.core.controller.NavigationApplication
+import dev.enro.core.controller.NavigationComponentBuilderCommand
 import dev.enro.core.controller.NavigationController
+import java.lang.reflect.Field
 
 object EnroTest {
+    val generatedBindings: List<Class<*>> by lazy {
+        getDexFiles()
+            .flatMap {
+                it.entries().asSequence()
+            }
+            .filter { it.startsWith("enro_generated_binding") }
+            .mapNotNull {
+                runCatching { Class.forName(it) }.getOrNull()
+            }
+            .filter {
+                NavigationComponentBuilderCommand::class.java.isAssignableFrom(it)
+            }
+            .toList()
+    }
+
     fun getCurrentNavigationController(): NavigationController {
         val application = ApplicationProvider.getApplicationContext<Application>()
         val navigationApplication = application as? NavigationApplication
@@ -13,4 +32,34 @@ object EnroTest {
 
         return navigationApplication.navigationController
     }
+}
+
+
+private fun getDexFiles(): Sequence<DexFile> {
+    // Here we do some reflection to access the dex files from the class loader. These implementation details vary by platform version,
+    // so we have to be a little careful, but not a huge deal since this is just for testing. It should work on 21+.
+    // The source for reference is at:
+    // https://android.googlesource.com/platform/libcore/+/oreo-release/dalvik/src/main/java/dalvik/system/BaseDexClassLoader.java
+    val classLoader = Thread.currentThread().contextClassLoader as BaseDexClassLoader
+
+    val pathListField = field("dalvik.system.BaseDexClassLoader", "pathList")
+    val pathList = pathListField.get(classLoader) // Type is DexPathList
+
+    val dexElementsField = field("dalvik.system.DexPathList", "dexElements")
+
+    @Suppress("UNCHECKED_CAST")
+    val dexElements =
+        dexElementsField.get(pathList) as Array<Any> // Type is Array<DexPathList.Element>
+
+    val dexFileField = field("dalvik.system.DexPathList\$Element", "dexFile")
+    return dexElements.map {
+        dexFileField.get(it) as DexFile
+    }.asSequence()
+}
+
+private fun field(className: String, fieldName: String): Field {
+    val clazz = Class.forName(className)
+    val field = clazz.getDeclaredField(fieldName)
+    field.isAccessible = true
+    return field
 }

--- a/enro-test/src/main/java/dev/enro/test/EnroTestRule.kt
+++ b/enro-test/src/main/java/dev/enro/test/EnroTestRule.kt
@@ -16,6 +16,7 @@ class EnroTestRule : TestRule {
 }
 
 fun runEnroTest(block: () -> Unit) {
+    EnroTest.installNavigationController()
     val navigationController = EnroTest.getCurrentNavigationController()
     navigationController.isInTest = true
     try {
@@ -23,6 +24,7 @@ fun runEnroTest(block: () -> Unit) {
     }
     finally {
         navigationController.isInTest = false
+        EnroTest.uninstallNavigationController()
     }
 }
 

--- a/modularised-example/app/build.gradle
+++ b/modularised-example/app/build.gradle
@@ -28,7 +28,11 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
@@ -61,11 +65,16 @@ dependencies {
     kapt 'androidx.hilt:hilt-compiler:1.0.0-beta01'
     kapt 'com.google.dagger:hilt-android-compiler:2.31-alpha'
 
+    testImplementation "org.robolectric:robolectric:4.4"
+
     implementation 'com.google.android.material:material:1.4.0-alpha01'
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'androidx.test.ext:junit:1.1.2'
     testImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     testImplementation project(":enro-test")
+
+    testImplementation 'com.google.dagger:hilt-android-testing:2.31-alpha'
+    kaptTest 'com.google.dagger:hilt-android-compiler:2.31-alpha'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/modularised-example/app/build.gradle
+++ b/modularised-example/app/build.gradle
@@ -63,8 +63,13 @@ dependencies {
 
     implementation 'com.google.android.material:material:1.4.0-alpha01'
     testImplementation 'junit:junit:4.13.1'
+    testImplementation 'androidx.test.ext:junit:1.1.2'
+    testImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    testImplementation project(":enro-test")
+
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation project(":enro-test")
 
 }
 kapt {

--- a/modularised-example/app/src/test/java/dev/enro/example/modularised/ModularisedExampleTest.kt
+++ b/modularised-example/app/src/test/java/dev/enro/example/modularised/ModularisedExampleTest.kt
@@ -1,0 +1,34 @@
+package dev.enro.example.modularised
+
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import dagger.hilt.android.testing.HiltTestApplication
+import dev.enro.example.core.navigation.LaunchKey
+import dev.enro.test.EnroTestRule
+import dev.enro.test.expectOpenInstruction
+import dev.enro.test.extensions.getTestNavigationHandle
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@HiltAndroidTest
+@Config(sdk = [28], application = HiltTestApplication::class)
+class ModularisedExampleTest {
+
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
+    @get:Rule
+    val enroRule = EnroTestRule()
+
+    @Test
+    fun whenMainActivityScenarioIsLaunched_thenLaunchKeyIsOpenedAsReplace() {
+        val scenario = ActivityScenario.launch(MainActivity::class.java)
+        scenario.getTestNavigationHandle<MainKey>()
+            .expectOpenInstruction<LaunchKey>()
+    }
+}


### PR DESCRIPTION
In some test scenarios (such as with HiltTestApplication) it is useful to be able to attach a NavigationController directly to an existing application that can't implement NavigationApplication. This PR will add changes that allow this, and will enable the EnroTestRule to attach a NavigationController to one of these applications, based on the classes in the package enro_generated_bindings (found with reflection).