### PR TITLE
Issue #52 fix

### DIFF
--- a/enro-core/src/main/java/dev/enro/core/compose/ComposableContainer.kt
+++ b/enro-core/src/main/java/dev/enro/core/compose/ComposableContainer.kt
@@ -13,13 +13,20 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import dev.enro.core.*
 import dev.enro.core.internal.handle.NavigationHandleViewModel
 import dev.enro.core.internal.handle.getNavigationHandleViewModel
-import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import java.util.*
 
 internal class EnroDestinationStorage : ViewModel() {
     val destinations = mutableMapOf<String, MutableMap<String, ComposableDestinationContextReference>>()
+
+    override fun onCleared() {
+        destinations.values
+            .flatMap { it.values }
+            .forEach { it.viewModelStore.clear() }
+
+        super.onCleared()
+    }
 }
 
 sealed class EmptyBehavior {

--- a/enro-core/src/main/java/dev/enro/core/controller/lifecycle/NavigationLifecycleController.kt
+++ b/enro-core/src/main/java/dev/enro/core/controller/lifecycle/NavigationLifecycleController.kt
@@ -91,7 +91,7 @@ internal class NavigationLifecycleController(
     }
 
     private fun updateActiveNavigationContext(context: NavigationContext<*>) {
-        if (!context.activity.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) return
+        if (!context.lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) return
 
         // Sometimes the context will be in an invalid state to correctly update, and will throw,
         // in which case, we just ignore the exception

--- a/enro/src/androidTest/AndroidManifest.xml
+++ b/enro/src/androidTest/AndroidManifest.xml
@@ -17,5 +17,6 @@
         <activity android:name=".core.ImmediateOpenChildActivity"/>
         <activity android:name=".core.ImmediateOpenFragmentChildActivity"/>
         <activity android:name=".result.ViewModelForwardingResultActivity"/>
+        <activity android:name=".ActivityWithComposables"/>
     </application>
 </manifest>

--- a/enro/src/androidTest/java/dev/enro/TestDestinations.kt
+++ b/enro/src/androidTest/java/dev/enro/TestDestinations.kt
@@ -1,4 +1,7 @@
 package dev.enro
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.Composable
 import dev.enro.annotations.ExperimentalComposableDestination
 import dev.enro.annotations.NavigationDestination
@@ -47,6 +50,38 @@ class ActivityChildFragment : TestFragment() {
     val navigation by navigationHandle<ActivityChildFragmentKey>() {
         container(primaryFragmentContainer) {
             it is Nothing
+        }
+    }
+}
+
+@Parcelize data class ActivityWithComposablesKey(
+    val id: String,
+    val primaryContainerAccepts: List<Class<out NavigationKey>>,
+    val secondaryContainerAccepts: List<Class<out NavigationKey>>
+) : NavigationKey
+
+@NavigationDestination(ActivityWithComposablesKey::class)
+class ActivityWithComposables : AppCompatActivity() {
+
+    val navigation by navigationHandle<ActivityWithComposablesKey> {
+        defaultKey(ActivityWithComposablesKey(
+            id = "default",
+            primaryContainerAccepts = listOf(NavigationKey::class.java),
+            secondaryContainerAccepts = emptyList()
+        ))
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            TestComposable(
+                name = "ActivityWithComposablesKey(id = ${navigation.key.id})",
+                primaryContainerAccepts = { key ->
+                    navigation.key.primaryContainerAccepts.any {
+                        it.isAssignableFrom(key::class.java)
+                    }
+                }
+            )
         }
     }
 }

--- a/enro/src/androidTest/java/dev/enro/core/ActivityToComposableTests.kt
+++ b/enro/src/androidTest/java/dev/enro/core/ActivityToComposableTests.kt
@@ -1,10 +1,12 @@
 package dev.enro.core
 
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.*
 import androidx.test.core.app.ActivityScenario
 import dev.enro.*
 import dev.enro.core.compose.ComposableDestination
-import junit.framework.TestCase
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.util.*
 
@@ -26,5 +28,60 @@ class ActivityToComposableTests {
         expectContext<ComposableDestination, GenericComposableKey> {
             it.navigation.key.id == id
         }
+    }
+
+    @Test
+    fun givenStandaloneComposable_whenHostActivityCloses_thenComposableViewModelStoreIsCleared() {
+        val scenario = ActivityScenario.launch(DefaultActivity::class.java)
+        val handle = scenario.getNavigationHandle<DefaultActivityKey>()
+
+        handle.forward(GenericComposableKey(id = "StandaloneComposable"))
+
+        expectSingleFragmentActivity()
+
+        val context = expectContext<ComposableDestination, GenericComposableKey>()
+
+        val viewModel by ViewModelLazy(
+            viewModelClass = OnClearedTrackingViewModel::class,
+            storeProducer = { context.context.viewModelStore },
+            factoryProducer = { ViewModelProvider.NewInstanceFactory() }
+        )
+
+        assertFalse(viewModel.onClearedCalled)
+
+        context.navigation.close()
+
+        expectActivity<DefaultActivity>()
+        waitFor { viewModel.onClearedCalled }
+        assertTrue(viewModel.onClearedCalled)
+    }
+
+    @Test
+    fun givenActivityHostedComposable_whenHostActivityCloses_thenComposableViewModelStoreIsCleared() {
+        val scenario = ActivityScenario.launch(ActivityWithComposables::class.java)
+        val handle = scenario.getNavigationHandle<ActivityWithComposablesKey>()
+
+        handle.forward(GenericComposableKey(id = "ComposableViewModelExample"))
+
+        val context = expectContext<ComposableDestination, GenericComposableKey>()
+
+        val viewModel by ViewModelLazy(
+            viewModelClass = OnClearedTrackingViewModel::class,
+            storeProducer = { context.context.viewModelStore },
+            factoryProducer = { ViewModelProvider.NewInstanceFactory() }
+        )
+
+        handle.close()
+
+        waitFor { viewModel.onClearedCalled }
+        assertTrue(viewModel.onClearedCalled)
+    }
+}
+
+class OnClearedTrackingViewModel : ViewModel() {
+    var onClearedCalled = false
+
+    override fun onCleared() {
+        onClearedCalled = true
     }
 }


### PR DESCRIPTION
Addresses issue #52 by explicitly clearing each `ComposableDestination`'s `viewModelStore`. 

- Clear composable destinations viewModelStores on EnroDestinationStorage clearing
- Update active navigation context now checks lifecycleOwner's lifecycle instead of going through the NavigationHandle, to avoid crash after closing host activity
- Added tests to cover both of these cases