### PR TITLE
Allow registerForNavigationResult to be called outside of Fragments/Activities and fix issue with registerForNavigationResult within Lists/RecyclerViews

### DIFF
--- a/enro-core/build.gradle
+++ b/enro-core/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation deps.androidx.appcompat
     implementation deps.androidx.fragment
     implementation deps.androidx.activity
+    implementation deps.androidx.recyclerview
 
     compileOnly deps.hilt.android
     kapt deps.hilt.compiler

--- a/enro-core/src/main/java/dev/enro/core/NavigationHandleProperty.kt
+++ b/enro-core/src/main/java/dev/enro/core/NavigationHandleProperty.kt
@@ -1,10 +1,13 @@
 package dev.enro.core
 
+import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import dev.enro.core.internal.handle.getNavigationHandleViewModel
+import java.lang.IllegalStateException
 import java.lang.ref.WeakReference
 import kotlin.collections.set
 import kotlin.properties.ReadOnlyProperty
@@ -46,8 +49,6 @@ class NavigationHandleProperty<Key : NavigationKey> @PublishedApi internal const
     }
 }
 
-
-
 inline fun <reified T: NavigationKey> FragmentActivity.navigationHandle(
     noinline config: NavigationHandleConfiguration<T>.() -> Unit = {}
 ): NavigationHandleProperty<T> = NavigationHandleProperty(
@@ -71,3 +72,14 @@ fun NavigationContext<*>.getNavigationHandle(): NavigationHandle = getNavigation
 fun FragmentActivity.getNavigationHandle(): NavigationHandle = getNavigationHandleViewModel()
 
 fun Fragment.getNavigationHandle(): NavigationHandle = getNavigationHandleViewModel()
+
+fun View.getNavigationHandle(): NavigationHandle? = findViewTreeViewModelStoreOwner()?.getNavigationHandleViewModel()
+
+fun View.requireNavigationHandle(): NavigationHandle {
+    if(!isAttachedToWindow) {
+        throw IllegalStateException("$this is not attached to any Window, which is required to retrieve a NavigationHandle")
+    }
+    val viewModelStoreOwner = findViewTreeViewModelStoreOwner()
+        ?: throw IllegalStateException("Could not find ViewTreeViewModelStoreOwner for $this, which is required to retrieve a NavigationHandle")
+    return viewModelStoreOwner.getNavigationHandleViewModel()
+}

--- a/enro-core/src/main/java/dev/enro/core/compose/ComposableNavigationResult.kt
+++ b/enro-core/src/main/java/dev/enro/core/compose/ComposableNavigationResult.kt
@@ -4,9 +4,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisallowComposableCalls
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import dev.enro.core.result.EnroResult
 import dev.enro.core.result.EnroResultChannel
 import dev.enro.core.result.internal.ResultChannelImpl
+import java.util.*
 
 
 @Composable
@@ -14,11 +16,15 @@ inline fun <reified T: Any> registerForNavigationResult(
     noinline onResult: @DisallowComposableCalls (T) -> Unit
 ): EnroResultChannel<T> {
     val navigationHandle = navigationHandle()
-    val resultChannel = remember {
+    val resultId = rememberSaveable {
+        UUID.randomUUID().toString()
+    }
+    val resultChannel = remember(onResult) {
         ResultChannelImpl(
             navigationHandle = navigationHandle,
             resultType = T::class.java,
-            onResult = onResult
+            onResult = onResult,
+            resultId = resultId
         )
     }
 

--- a/enro-core/src/main/java/dev/enro/core/compose/ComposableNavigationResult.kt
+++ b/enro-core/src/main/java/dev/enro/core/compose/ComposableNavigationResult.kt
@@ -15,6 +15,11 @@ inline fun <reified T: Any> registerForNavigationResult(
     noinline onResult: @DisallowComposableCalls (T) -> Unit
 ): EnroResultChannel<T> {
     val navigationHandle = navigationHandle()
+
+    // Remember a random UUID that will be used to uniquely identify this result channel
+    // within the composition. This is important to ensure that results are delivered if a Composable
+    // is used multiple times within the same composition (such as within a list).
+    // See ComposableListResultTests
     val resultId = rememberSaveable {
         UUID.randomUUID().toString()
     }
@@ -23,7 +28,7 @@ inline fun <reified T: Any> registerForNavigationResult(
             navigationHandle = navigationHandle,
             resultType = T::class.java,
             onResult = onResult,
-            resultId = resultId
+            additionalResultId = resultId
         )
     }
 

--- a/enro-core/src/main/java/dev/enro/core/compose/ComposableNavigationResult.kt
+++ b/enro-core/src/main/java/dev/enro/core/compose/ComposableNavigationResult.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.DisallowComposableCalls
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
-import dev.enro.core.result.EnroResult
 import dev.enro.core.result.EnroResultChannel
 import dev.enro.core.result.internal.ResultChannelImpl
 import java.util.*
@@ -29,9 +28,9 @@ inline fun <reified T: Any> registerForNavigationResult(
     }
 
     DisposableEffect(true) {
-        EnroResult.from(navigationHandle.controller).registerChannel(resultChannel)
+        resultChannel.attach()
         onDispose {
-            EnroResult.from(navigationHandle.controller).deregisterChannel(resultChannel)
+            resultChannel.detach()
         }
     }
     return resultChannel

--- a/enro-core/src/main/java/dev/enro/core/result/EnroResult.kt
+++ b/enro-core/src/main/java/dev/enro/core/result/EnroResult.kt
@@ -56,11 +56,6 @@ internal class EnroResult: EnroPlugin() {
         channels.remove(channel.id)
     }
 
-    // Called reflectively in tests
-    private fun getActiveChannelsForTest(): List<EnroResultChannel<*>> {
-        return channels.values.toList()
-    }
-
     companion object {
         private val controllerBindings = mutableMapOf<NavigationController, EnroResult>()
 

--- a/enro-core/src/main/java/dev/enro/core/result/EnroResult.kt
+++ b/enro-core/src/main/java/dev/enro/core/result/EnroResult.kt
@@ -56,6 +56,7 @@ internal class EnroResult: EnroPlugin() {
         channels.remove(channel.id)
     }
 
+    // Called reflectively in tests
     private fun getActiveChannelsForTest(): List<EnroResultChannel<*>> {
         return channels.values.toList()
     }

--- a/enro-core/src/main/java/dev/enro/core/result/EnroResult.kt
+++ b/enro-core/src/main/java/dev/enro/core/result/EnroResult.kt
@@ -56,6 +56,10 @@ internal class EnroResult: EnroPlugin() {
         channels.remove(channel.id)
     }
 
+    private fun getActiveChannelsForTest(): List<EnroResultChannel<*>> {
+        return channels.values.toList()
+    }
+
     companion object {
         private val controllerBindings = mutableMapOf<NavigationController, EnroResult>()
 

--- a/enro-core/src/main/java/dev/enro/core/result/EnroResultChannel.kt
+++ b/enro-core/src/main/java/dev/enro/core/result/EnroResultChannel.kt
@@ -5,3 +5,8 @@ import dev.enro.core.NavigationKey
 interface EnroResultChannel<T> {
     fun open(key: NavigationKey.WithResult<T>)
 }
+
+interface UnmanagedEnroResultChannel<T> : EnroResultChannel<T> {
+    fun attach()
+    fun detach()
+}

--- a/enro-core/src/main/java/dev/enro/core/result/EnroResultChannel.kt
+++ b/enro-core/src/main/java/dev/enro/core/result/EnroResultChannel.kt
@@ -6,7 +6,38 @@ interface EnroResultChannel<T> {
     fun open(key: NavigationKey.WithResult<T>)
 }
 
+/**
+ * An UnmanagedEnroResultChannel is an EnroResultChannel that does not manage its own lifecycle.
+ *
+ * An UnmanagedEnroResultChannel will always be destroyed when the NavigationHandle that was used to
+ * create it is destroyed (unless the UnmanagedEnroResultChannel has been destroyed before this).
+ *
+ * An EnroResultChannel is usually tied to the lifecycle of some UI component, such as a Fragment,
+ * Activity, or Composable function. When this UI component is not visible, the EnroResultChannel
+ * will enter a detached state, which means it will not receive updates until the UI component is
+ * visible again. When the UI component becomes visible, it will be attached again and will receive
+ * any pending results, as well as being ready to receive any other results that are sent.
+ *
+ * An UnmanagedEnroResult channel allows you to manage the attach, detach, and destroy events of the
+ * EnroResultChannel yourself.
+ *
+ * This is primarily useful when a component wants to maintain a lifecycle that is shorter than
+ * the regular Activity/Fragment/ViewModel lifecycles. For example, in the ViewHolder for a RecyclerView,
+ * result channels should be destroyed when their associated View is detached/recycled, otherwise you
+ * could end up with thousands of active result channels. Similarly, if a custom View maintains a
+ * result channel, it may be useful to tie the UnmanagedEnroResultChannel's attach/detach to the
+ * View's onAttachedToWindow/onDetachedFromWindow, so that the View does not receive results while it
+ * is not attached to a window.
+ *
+ * There are extension functions available to manage an UnmanagedEnroResultChannel with a Lifecycle,
+ * View, or ViewHolder.
+ *
+ * @see managedByLifecycle
+ * @see managedByView
+ * @see managedByViewHolderItem
+ */
 interface UnmanagedEnroResultChannel<T> : EnroResultChannel<T> {
     fun attach()
     fun detach()
+    fun destroy()
 }

--- a/enro-core/src/main/java/dev/enro/core/result/EnroResultExtensions.kt
+++ b/enro-core/src/main/java/dev/enro/core/result/EnroResultExtensions.kt
@@ -123,7 +123,7 @@ inline fun <reified T : Any> NavigationHandle.registerForNavigationResult(
         navigationHandle = this,
         resultType = T::class.java,
         onResult = onResult,
-        resultId = id
+        additionalResultId = id
     )
 }
 

--- a/enro-core/src/main/java/dev/enro/core/result/EnroResultExtensions.kt
+++ b/enro-core/src/main/java/dev/enro/core/result/EnroResultExtensions.kt
@@ -1,13 +1,16 @@
 package dev.enro.core.result
 
+import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.*
+import androidx.recyclerview.widget.RecyclerView
 import dev.enro.core.*
 import dev.enro.core.result.internal.LazyResultChannelProperty
 import dev.enro.core.result.internal.PendingResult
 import dev.enro.core.result.internal.ResultChannelImpl
 import dev.enro.core.synthetic.SyntheticDestination
+import java.lang.IllegalStateException
 import kotlin.properties.ReadOnlyProperty
 
 fun <T : Any> TypedNavigationHandle<out NavigationKey.WithResult<T>>.closeWithResult(result: T) {
@@ -102,14 +105,109 @@ inline fun <reified T : Any> Fragment.registerForNavigationResult(
         onResult = onResult
     )
 
+/**
+ * Register for an UnmanagedEnroResultChannel.
+ *
+ * Be aware that you need to manage the attach/detach/destroy lifecycle events of this result channel
+ * yourself, including the initial attach.
+ *
+ * @see UnmanagedEnroResultChannel
+ * @see managedByLifecycle
+ * @see managedByView
+ */
 inline fun <reified T : Any> NavigationHandle.registerForNavigationResult(
     id: String,
     noinline onResult: (T) -> Unit
-): EnroResultChannel<T> {
+): UnmanagedEnroResultChannel<T> {
     return ResultChannelImpl(
         navigationHandle = this,
         resultType = T::class.java,
         onResult = onResult,
         resultId = id
-    ).apply { attach() }
+    )
+}
+
+/**
+ * Sets up an UnmanagedEnroResultChannel to be managed by a Lifecycle.
+ *
+ * The result channel will be attached when the ON_START event occurs, detached when the ON_STOP
+ * event occurs, and destroyed when ON_DESTROY occurs.
+ */
+fun <T> UnmanagedEnroResultChannel<T>.managedByLifecycle(lifecycle: Lifecycle): EnroResultChannel<T> {
+    lifecycle.addObserver(LifecycleEventObserver { _, event ->
+        if(event == Lifecycle.Event.ON_START) attach()
+        if(event == Lifecycle.Event.ON_STOP) detach()
+        if(event == Lifecycle.Event.ON_DESTROY) destroy()
+    })
+    return this
+}
+
+/**
+ * Sets up an UnmanagedEnroResultChannel to be managed by a View.
+ *
+ * The result channel will be attached when the View is attached to a Window,
+ * detached when the view is detached from a Window, and destroyed when the ViewTreeLifecycleOwner
+ * lifecycle receives the ON_DESTROY event.
+ */
+fun <T> UnmanagedEnroResultChannel<T>.managedByView(view: View): EnroResultChannel<T> {
+    var activeLifecycle: Lifecycle? = null
+    val lifecycleObserver = LifecycleEventObserver { _, event ->
+        if(event == Lifecycle.Event.ON_DESTROY) destroy()
+    }
+
+    if(view.isAttachedToWindow) {
+        attach()
+        val lifecycleOwner = view.findViewTreeLifecycleOwner() ?: throw IllegalStateException()
+        activeLifecycle = lifecycleOwner.lifecycle.apply {
+            addObserver(lifecycleObserver)
+        }
+    }
+
+    view.addOnAttachStateChangeListener(object: View.OnAttachStateChangeListener {
+        override fun onViewAttachedToWindow(v: View?) {
+            activeLifecycle?.removeObserver(lifecycleObserver)
+
+            attach()
+            val lifecycleOwner = view.findViewTreeLifecycleOwner() ?: throw IllegalStateException()
+            activeLifecycle = lifecycleOwner.lifecycle.apply {
+                addObserver(lifecycleObserver)
+            }
+        }
+
+        override fun onViewDetachedFromWindow(v: View?) {
+            detach()
+        }
+    })
+    return this
+}
+
+/**
+ * Sets up an UnmanagedEnroResultChannel to be managed by a ViewHolder's itemView.
+ *
+ * The result channel will be attached when the ViewHolder's itemView is attached to a Window,
+ * and destroyed when the ViewHolder's itemView is detached from a Window.
+ *
+ * It is important to understand that this management strategy is appropriate to be called when a
+ * ViewHolder is bound to a particular item from the RecyclerView Adapter, not in the constructor of the
+ * ViewHolder. When RecyclerView items are recycled, they are first detached from the Window and then re-bound,
+ * and then re-attached to the Window. This management strategy will cause the result channel to be
+ * destroyed every time the ViewHolder is re-bound to data through onBindViewHolder, which means the
+ * result channel should be created each time the ViewHolder is bound.
+ */
+fun <T> UnmanagedEnroResultChannel<T>.managedByViewHolderItem(viewHolder: RecyclerView.ViewHolder): EnroResultChannel<T> {
+    if(viewHolder.itemView.isAttachedToWindow) {
+        attach()
+    }
+
+    viewHolder.itemView.addOnAttachStateChangeListener(object: View.OnAttachStateChangeListener {
+        override fun onViewAttachedToWindow(v: View?) {
+            attach()
+        }
+
+        override fun onViewDetachedFromWindow(v: View?) {
+            destroy()
+            viewHolder.itemView.removeOnAttachStateChangeListener(this)
+        }
+    })
+    return this
 }

--- a/enro-core/src/main/java/dev/enro/core/result/EnroResultExtensions.kt
+++ b/enro-core/src/main/java/dev/enro/core/result/EnroResultExtensions.kt
@@ -103,9 +103,13 @@ inline fun <reified T : Any> Fragment.registerForNavigationResult(
     )
 
 inline fun <reified T : Any> NavigationHandle.registerForNavigationResult(
+    id: String,
     noinline onResult: (T) -> Unit
-): EnroResultChannel<T> = ResultChannelImpl(
-    navigationHandle = this,
-    resultType = T::class.java,
-    onResult = onResult
-)
+): EnroResultChannel<T> {
+    return ResultChannelImpl(
+        navigationHandle = this,
+        resultType = T::class.java,
+        onResult = onResult,
+        resultId = id
+    ).apply { attach() }
+}

--- a/enro-core/src/main/java/dev/enro/core/result/EnroResultExtensions.kt
+++ b/enro-core/src/main/java/dev/enro/core/result/EnroResultExtensions.kt
@@ -93,32 +93,6 @@ inline fun <reified T : Any> FragmentActivity.registerForNavigationResult(
         onResult = onResult
     )
 
-
-//ManagedResultChannel<T> {
-//    val navigationHandle = this
-//    return object : ManagedResultChannel<T> {
-//        val channel = ResultChannelImpl(
-//            navigationHandle = navigationHandle,
-//            resultType = T::class.java,
-//            onResult = onResult,
-//            resultId = resultId
-//        )
-//
-//        override fun open(key: NavigationKey.WithResult<T>) {
-//            channel.open(key)
-//        }
-//
-//        override fun setActive() {
-//            EnroResult.from(navigationHandle.controller)
-//                .registerChannel(channel)
-//        }
-//
-//        override fun setInactive() {
-//            EnroResult.from(navigationHandle.controller)
-//                .deregisterChannel(channel)
-//        }
-//    }
-
 inline fun <reified T : Any> Fragment.registerForNavigationResult(
     noinline onResult: (T) -> Unit
 ): ReadOnlyProperty<Fragment, EnroResultChannel<T>> =

--- a/enro-core/src/main/java/dev/enro/core/result/EnroResultExtensions.kt
+++ b/enro-core/src/main/java/dev/enro/core/result/EnroResultExtensions.kt
@@ -93,6 +93,32 @@ inline fun <reified T : Any> FragmentActivity.registerForNavigationResult(
         onResult = onResult
     )
 
+
+//ManagedResultChannel<T> {
+//    val navigationHandle = this
+//    return object : ManagedResultChannel<T> {
+//        val channel = ResultChannelImpl(
+//            navigationHandle = navigationHandle,
+//            resultType = T::class.java,
+//            onResult = onResult,
+//            resultId = resultId
+//        )
+//
+//        override fun open(key: NavigationKey.WithResult<T>) {
+//            channel.open(key)
+//        }
+//
+//        override fun setActive() {
+//            EnroResult.from(navigationHandle.controller)
+//                .registerChannel(channel)
+//        }
+//
+//        override fun setInactive() {
+//            EnroResult.from(navigationHandle.controller)
+//                .deregisterChannel(channel)
+//        }
+//    }
+
 inline fun <reified T : Any> Fragment.registerForNavigationResult(
     noinline onResult: (T) -> Unit
 ): ReadOnlyProperty<Fragment, EnroResultChannel<T>> =
@@ -101,3 +127,11 @@ inline fun <reified T : Any> Fragment.registerForNavigationResult(
         resultType = T::class.java,
         onResult = onResult
     )
+
+inline fun <reified T : Any> NavigationHandle.registerForNavigationResult(
+    noinline onResult: (T) -> Unit
+): EnroResultChannel<T> = ResultChannelImpl(
+    navigationHandle = this,
+    resultType = T::class.java,
+    onResult = onResult
+)

--- a/enro-core/src/main/java/dev/enro/core/result/internal/LazyResultChannelProperty.kt
+++ b/enro-core/src/main/java/dev/enro/core/result/internal/LazyResultChannelProperty.kt
@@ -2,11 +2,11 @@ package dev.enro.core.result.internal
 
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.*
 import dev.enro.core.NavigationHandle
 import dev.enro.core.getNavigationHandle
+import dev.enro.core.result.EnroResultChannel
+import dev.enro.core.result.managedByLifecycle
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
@@ -15,9 +15,9 @@ internal class LazyResultChannelProperty<T>(
     owner: Any,
     resultType: Class<T>,
     onResult: (T) -> Unit
-) : ReadOnlyProperty<Any, ResultChannelImpl<T>> {
+) : ReadOnlyProperty<Any, EnroResultChannel<T>> {
 
-    var resultChannel: ResultChannelImpl<T>? = null
+    private var resultChannel: EnroResultChannel<T>? = null
 
     init {
         val handle = when (owner) {
@@ -26,38 +26,20 @@ internal class LazyResultChannelProperty<T>(
             is NavigationHandle -> lazy { owner as NavigationHandle }
             else -> throw IllegalArgumentException("Owner must be a Fragment, FragmentActivity, or NavigationHandle")
         }
-        val lifecycle = owner as LifecycleOwner
+        val lifecycleOwner = owner as LifecycleOwner
+        val lifecycle = lifecycleOwner.lifecycle
 
-        lifecycle.lifecycle.addObserver(object : LifecycleEventObserver {
-            override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
-                when (event) {
-                    Lifecycle.Event.ON_CREATE -> {
-                        resultChannel = ResultChannelImpl(
-                            navigationHandle = handle.value,
-                            resultType = resultType,
-                            onResult = onResult
-                        )
-                    }
-                    Lifecycle.Event.ON_START -> {
-                        resultChannel?.attach()
-                    }
-                    Lifecycle.Event.ON_STOP -> {
-                        resultChannel?.detach()
-                    }
-                    Lifecycle.Event.ON_DESTROY -> {
-                        lifecycle.lifecycle.removeObserver(this)
-                        resultChannel = null
-                    }
-                    else -> {
-                        // Do nothing
-                    }
-                }
-            }
-        })
+        lifecycle.coroutineScope.launchWhenCreated {
+            resultChannel = ResultChannelImpl(
+                navigationHandle = handle.value,
+                resultType = resultType,
+                onResult = onResult
+            ).managedByLifecycle(lifecycle)
+        }
     }
 
     override fun getValue(
         thisRef: Any,
         property: KProperty<*>
-    ): ResultChannelImpl<T> = resultChannel!!
+    ): EnroResultChannel<T> = resultChannel!!
 }

--- a/enro-core/src/main/java/dev/enro/core/result/internal/LazyResultChannelProperty.kt
+++ b/enro-core/src/main/java/dev/enro/core/result/internal/LazyResultChannelProperty.kt
@@ -7,9 +7,6 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import dev.enro.core.NavigationHandle
 import dev.enro.core.getNavigationHandle
-import dev.enro.core.navigationContext
-import dev.enro.core.result.EnroResult
-import dev.enro.core.synthetic.SyntheticDestination
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
@@ -42,16 +39,10 @@ internal class LazyResultChannelProperty<T>(
                         )
                     }
                     Lifecycle.Event.ON_START -> {
-                        EnroResult.from(handle.value.controller)
-                            .apply {
-                                registerChannel(resultChannel ?: return)
-                            }
+                        resultChannel?.attach()
                     }
                     Lifecycle.Event.ON_STOP -> {
-                        EnroResult.from(handle.value.controller)
-                            .apply {
-                                deregisterChannel(resultChannel ?: return)
-                            }
+                        resultChannel?.detach()
                     }
                     Lifecycle.Event.ON_DESTROY -> {
                         lifecycle.lifecycle.removeObserver(this)

--- a/enro-core/src/main/java/dev/enro/core/result/internal/ResultChannelImpl.kt
+++ b/enro-core/src/main/java/dev/enro/core/result/internal/ResultChannelImpl.kt
@@ -29,7 +29,7 @@ class ResultChannelImpl<T> @PublishedApi internal constructor(
     /**
      * The arguments passed to the ResultChannelImpl hold references to the external world, and
      * can hold references to objects that could leak in memory. We store these properties inside
-     * an variable which is cleared to null when the ResultChannelImpl is destroyed, to ensure
+     * a variable which is cleared to null when the ResultChannelImpl is destroyed, to ensure
      * that these references are not held by the ResultChannelImpl after it has been destroyed.
      */
     private var arguments: ResultChannelProperties<T>? = ResultChannelProperties(

--- a/enro-core/src/main/java/dev/enro/core/result/internal/ResultChannelImpl.kt
+++ b/enro-core/src/main/java/dev/enro/core/result/internal/ResultChannelImpl.kt
@@ -19,7 +19,8 @@ private const val EXTRA_RESULT_CHANNEL_ID = "com.enro.core.RESULT_CHANNEL_ID"
 class ResultChannelImpl<T> @PublishedApi internal constructor(
     private val navigationHandle: NavigationHandle,
     private val resultType: Class<T>,
-    private val onResult: (T) -> Unit
+    private val onResult: (T) -> Unit,
+    private val resultId: String = "",
 ) : EnroResultChannel<T> {
     /**
      * The resultId being set here to the JVM class name of the onResult lambda is a key part of
@@ -52,7 +53,7 @@ class ResultChannelImpl<T> @PublishedApi internal constructor(
      */
     internal val id = ResultChannelId(
         ownerId = navigationHandle.id,
-        resultId = onResult::class.java.name
+        resultId = onResult::class.java.name +"@"+resultId
     )
 
     override fun open(key: NavigationKey.WithResult<T>) {

--- a/enro/build.gradle
+++ b/enro/build.gradle
@@ -44,10 +44,12 @@ dependencies {
     androidTestImplementation deps.androidx.appcompat
     androidTestImplementation deps.androidx.fragment
     androidTestImplementation deps.androidx.activity
+    androidTestImplementation deps.androidx.recyclerview
 
     androidTestImplementation deps.testing.androidx.fragment
     androidTestImplementation deps.testing.androidx.junit
     androidTestImplementation deps.testing.androidx.espresso
+    androidTestImplementation deps.testing.androidx.espressoRecyclerView
     androidTestImplementation deps.testing.androidx.espressoIntents
     androidTestImplementation deps.testing.androidx.runner
 

--- a/enro/src/androidTest/AndroidManifest.xml
+++ b/enro/src/androidTest/AndroidManifest.xml
@@ -20,5 +20,6 @@
         <activity android:name=".ActivityWithComposables"/>
         <activity android:name=".core.ComposableTestActivity" />
         <activity android:name="androidx.activity.ComponentActivity"/>
+        <activity android:name=".result.RecyclerViewResultActivity"/>
     </application>
 </manifest>

--- a/enro/src/androidTest/AndroidManifest.xml
+++ b/enro/src/androidTest/AndroidManifest.xml
@@ -21,5 +21,6 @@
         <activity android:name=".core.ComposableTestActivity" />
         <activity android:name="androidx.activity.ComponentActivity"/>
         <activity android:name=".result.RecyclerViewResultActivity"/>
+        <activity android:name=".result.ComposeRecyclerViewResultActivity"/>
     </application>
 </manifest>

--- a/enro/src/androidTest/java/dev/enro/TestExtensions.kt
+++ b/enro/src/androidTest/java/dev/enro/TestExtensions.kt
@@ -12,6 +12,9 @@ import androidx.test.runner.lifecycle.Stage
 import dev.enro.core.*
 import dev.enro.core.compose.ComposableDestination
 import dev.enro.core.compose.composableManger
+import dev.enro.core.controller.NavigationController
+import dev.enro.core.controller.navigationController
+import dev.enro.core.result.EnroResultChannel
 
 private val debug = false
 
@@ -161,6 +164,16 @@ fun <T: Any> waitOnMain(block: () -> T?): T {
         }
         currentResponse?.let { return it }
     }
+}
+
+fun getActiveEnroResultChannels(): List<EnroResultChannel<*>> {
+    val enroResultClass = Class.forName("dev.enro.core.result.EnroResult")
+    val getEnroResult = enroResultClass.getDeclaredMethod("from", NavigationController::class.java)
+    getEnroResult.isAccessible = true
+    val enroResult = getEnroResult.invoke(null, application.navigationController)
+    getEnroResult.isAccessible = false
+
+    return enroResult.callPrivate("getActiveChannelsForTest")
 }
 
 fun <T> Any.callPrivate(methodName: String, vararg args: Any): T {

--- a/enro/src/androidTest/java/dev/enro/TestExtensions.kt
+++ b/enro/src/androidTest/java/dev/enro/TestExtensions.kt
@@ -163,7 +163,7 @@ fun <T: Any> waitOnMain(block: () -> T?): T {
     }
 }
 
-private fun <T> Any.callPrivate(methodName: String, vararg args: Any): T {
+fun <T> Any.callPrivate(methodName: String, vararg args: Any): T {
     val method = this::class.java.declaredMethods.filter { it.name.startsWith(methodName) }.first()
     method.isAccessible = true
     val result = method.invoke(this, *args)

--- a/enro/src/androidTest/java/dev/enro/TestExtensions.kt
+++ b/enro/src/androidTest/java/dev/enro/TestExtensions.kt
@@ -173,13 +173,22 @@ fun getActiveEnroResultChannels(): List<EnroResultChannel<*>> {
     val enroResult = getEnroResult.invoke(null, application.navigationController)
     getEnroResult.isAccessible = false
 
-    return enroResult.callPrivate("getActiveChannelsForTest")
+    val channels = enroResult.getPrivate<Map<Any, EnroResultChannel<*>>>("channels")
+    return channels.values.toList()
 }
 
 fun <T> Any.callPrivate(methodName: String, vararg args: Any): T {
     val method = this::class.java.declaredMethods.filter { it.name.startsWith(methodName) }.first()
     method.isAccessible = true
     val result = method.invoke(this, *args)
+    method.isAccessible = false
+    return result as T
+}
+
+fun <T> Any.getPrivate(methodName: String): T {
+    val method = this::class.java.declaredFields.filter { it.name.startsWith(methodName) }.first()
+    method.isAccessible = true
+    val result = method.get(this)
     method.isAccessible = false
     return result as T
 }

--- a/enro/src/androidTest/java/dev/enro/TestExtensions.kt
+++ b/enro/src/androidTest/java/dev/enro/TestExtensions.kt
@@ -163,5 +163,13 @@ fun <T: Any> waitOnMain(block: () -> T?): T {
     }
 }
 
+private fun <T> Any.callPrivate(methodName: String, vararg args: Any): T {
+    val method = this::class.java.declaredMethods.filter { it.name.startsWith(methodName) }.first()
+    method.isAccessible = true
+    val result = method.invoke(this, *args)
+    method.isAccessible = false
+    return result as T
+}
+
 val application: Application get() =
     InstrumentationRegistry.getInstrumentation().context.applicationContext as Application

--- a/enro/src/androidTest/java/dev/enro/result/ComposableListResultTests.kt
+++ b/enro/src/androidTest/java/dev/enro/result/ComposableListResultTests.kt
@@ -35,10 +35,6 @@ class ComposableListResultTests {
         composeContentRule.setContent {
             ListItemWithResult(id = id)
         }
-        composeContentRule.onNodeWithTag("result@$id").assertTextEquals("EMPTY")
-        composeContentRule.onNodeWithTag("button@$id").performClick()
-        composeContentRule.onNodeWithTag("result@$id").assertTextEquals(id)
-
         assertResultIsReceivedFor(id)
     }
 
@@ -59,7 +55,7 @@ class ComposableListResultTests {
     }
 
     @Test
-    fun whenMultipleListItemWithResultsAreRenderedInLazColumn_thenResultIsRetrievedSuccessfullyToTheCorrectItem() {
+    fun whenMultipleListItemWithResultsAreRenderedInLazyColumn_thenResultIsRetrievedSuccessfullyToTheCorrectItem() {
         val ids = List(500) { UUID.randomUUID().toString() }
         val state = LazyListState()
         val scrollTarget = mutableStateOf(0)

--- a/enro/src/androidTest/java/dev/enro/result/ComposableListResultTests.kt
+++ b/enro/src/androidTest/java/dev/enro/result/ComposableListResultTests.kt
@@ -114,7 +114,6 @@ class ComposableListResultTests {
     fun whenHundredsOfListItemWithResultsAreRendered_andScreenIsScrolled_thenNonVisibleResultChannelsAreCleanedUp() {
         val ids = List(5000) { UUID.randomUUID().toString() }
         val state = LazyListState()
-        val scrollTarget = mutableStateOf(0)
         composeContentRule.setContent {
             LazyColumn(
                 state = state

--- a/enro/src/androidTest/java/dev/enro/result/ComposableListResultTests.kt
+++ b/enro/src/androidTest/java/dev/enro/result/ComposableListResultTests.kt
@@ -1,0 +1,137 @@
+package dev.enro.result
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
+import dev.enro.DefaultActivity
+import dev.enro.core.compose.registerForNavigationResult
+import org.junit.Rule
+import org.junit.Test
+import java.util.*
+
+
+class ComposableListResultTests {
+    @get:Rule
+    val composeContentRule = createAndroidComposeRule<DefaultActivity>()
+
+    @Test
+    fun whenListItemWithResultIsRenderedOnItsOwn_thenResultIsRetrievedSuccessfully() {
+        val id = UUID.randomUUID().toString()
+        composeContentRule.setContent {
+            ListItemWithResult(id = id)
+        }
+        composeContentRule.onNodeWithTag("result@$id").assertTextEquals("EMPTY")
+        composeContentRule.onNodeWithTag("button@$id").performClick()
+        composeContentRule.onNodeWithTag("result@$id").assertTextEquals(id)
+
+        assertResultIsReceivedFor(id)
+    }
+
+    @Test
+    fun whenMultipleListItemWithResultsAreRendered_thenResultIsRetrievedSuccessfullyToTheCorrectItem() {
+        val ids = List(5) { UUID.randomUUID().toString() }
+        composeContentRule.setContent {
+            Column {
+                ids.forEach {
+                    ListItemWithResult(id = it)
+                }
+            }
+        }
+
+        assertResultIsReceivedFor(ids[0])
+        assertResultIsReceivedFor(ids[2])
+        assertResultIsReceivedFor(ids[4])
+    }
+
+    @Test
+    fun whenMultipleListItemWithResultsAreRenderedInLazColumn_thenResultIsRetrievedSuccessfullyToTheCorrectItem() {
+        val ids = List(500) { UUID.randomUUID().toString() }
+        val state = LazyListState()
+        val scrollTarget = mutableStateOf(0)
+        composeContentRule.setContent {
+            LazyColumn(
+                state = state
+            ) {
+                items(ids) {
+                    ListItemWithResult(id = it)
+                }
+            }
+            LaunchedEffect(scrollTarget.value) {
+                state.animateScrollToItem(scrollTarget.value)
+            }
+        }
+        scrollTarget.value = 100
+        composeContentRule.waitForIdle()
+        assertResultIsReceivedFor(ids[100])
+
+        scrollTarget.value = 460
+        composeContentRule.waitForIdle()
+        assertResultIsReceivedFor(ids[460])
+
+        scrollTarget.value = 10
+        composeContentRule.waitForIdle()
+        assertResultIsReceivedFor(ids[10])
+
+        scrollTarget.value = 420
+        composeContentRule.waitForIdle()
+        assertResultIsReceivedFor(ids[420])
+
+        scrollTarget.value = 0
+        composeContentRule.waitForIdle()
+        assertResultIsReceivedFor(ids[0])
+    }
+
+    private fun assertResultIsReceivedFor(id: String) {
+        composeContentRule.onNodeWithTag("result@${id}").assertTextEquals("EMPTY")
+        composeContentRule.onNodeWithTag("button@${id}").performClick()
+        composeContentRule.onNodeWithTag("result@${id}").assertTextEquals(id.reversed())
+    }
+}
+
+@Composable
+private fun ListItemWithResult(
+    id: String,
+) {
+    val title = remember { mutableStateOf("EMPTY") }
+    val channel = registerForNavigationResult<String> {
+        title.value = it
+    }
+
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .testTag("row@$id")
+    ) {
+        Button(
+            onClick = {
+                channel.open(ImmediateSyntheticResultKey(id))
+             },
+            content = {
+                Text(text = "Get Result")
+            },
+            modifier = Modifier.testTag("button@$id")
+        )
+        Text(
+            text = title.value,
+            modifier = Modifier.testTag("result@$id")
+        )
+    }
+}

--- a/enro/src/androidTest/java/dev/enro/result/ComposableRecyclerViewResultTests.kt
+++ b/enro/src/androidTest/java/dev/enro/result/ComposableRecyclerViewResultTests.kt
@@ -1,0 +1,281 @@
+package dev.enro.result
+
+import android.os.Bundle
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import dev.enro.annotations.NavigationDestination
+import dev.enro.core.NavigationHandle
+import dev.enro.core.NavigationKey
+import dev.enro.core.compose.registerForNavigationResult
+import dev.enro.core.navigationHandle
+import dev.enro.getActiveEnroResultChannels
+import kotlinx.parcelize.Parcelize
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import java.util.*
+
+
+class ComposableRecyclerViewResultTests {
+    @get:Rule
+    val composeContentRule = createAndroidComposeRule<ComposeRecyclerViewResultActivity>()
+
+    @Test
+    fun whenListItemWithResultIsRenderedOnItsOwn_thenResultIsRetrievedSuccessfully() {
+        val scenario = composeContentRule.activityRule.scenario
+        scenario.onActivity {
+            it.setupItems(1)
+        }
+        scenario.assertResultIsReceivedFor(0)
+    }
+
+    @Test
+    fun whenMultipleListItemWithResultsAreRendered_andActivityIsDestroyed_thenResultChannelsAreCleanedUp() {
+        val scenario = composeContentRule.activityRule.scenario
+        scenario.onActivity {
+            it.setupItems(5)
+        }
+        Thread.sleep(1000)
+        assertEquals(5, getActiveEnroResultChannels().size)
+        scenario.close()
+        assertEquals(0, getActiveEnroResultChannels().size)
+    }
+
+    @Test
+    fun whenHundredsOfListItemWithResultsAreRendered_andScreenIsScrolled_thenNonVisibleResultChannelsAreCleanedUp() {
+        val scenario = composeContentRule.activityRule.scenario
+        scenario.onActivity {
+            it.setupItems(5000)
+        }
+        repeat(200) {
+            scenario.scrollTo(it * 10)
+        }
+        var maximumExpectedItems = 0
+        scenario.onActivity {
+            maximumExpectedItems = it.adapter.attachedViewHolderCount
+        }
+
+        val activeChannels = getActiveEnroResultChannels()
+        assertEquals(maximumExpectedItems, activeChannels.size)
+    }
+
+    @Test
+    fun whenMultipleListItemWithResultsAreRendered_thenResultIsRetrievedSuccessfullyToTheCorrectItem() {
+        val scenario = composeContentRule.activityRule.scenario
+        scenario.onActivity {
+            it.setupItems(5)
+        }
+
+        scenario.assertResultIsReceivedFor(0)
+        scenario.assertResultIsReceivedFor(2)
+        scenario.assertResultIsReceivedFor(4)
+    }
+
+    @Test
+    fun whenMultipleListItemWithResultsAreRenderedInRecyclerView_thenResultIsRetrievedSuccessfullyToTheCorrectItem() {
+        val scenario = composeContentRule.activityRule.scenario
+        scenario.onActivity {
+            it.setupItems(500)
+        }
+        scenario.scrollTo(100)
+        scenario.assertResultIsReceivedFor(100)
+
+        scenario.scrollTo(460)
+        scenario.assertResultIsReceivedFor(460)
+
+        scenario.scrollTo(10)
+        scenario.assertResultIsReceivedFor(10)
+
+        scenario.scrollTo(420)
+        scenario.assertResultIsReceivedFor(420)
+
+        scenario.scrollTo(0)
+        scenario.assertResultIsReceivedFor(0)
+    }
+
+
+    private val ActivityScenario<ComposeRecyclerViewResultActivity>.items: List<ComposeRecyclerViewItem>
+        get() {
+            lateinit var items: List<ComposeRecyclerViewItem>
+            onActivity {
+                items = it.items
+            }
+            return items
+        }
+
+    private fun ActivityScenario<ComposeRecyclerViewResultActivity>.assertResultIsReceivedFor(index: Int) {
+        val id = items[index].id
+        composeContentRule.onNodeWithTag("result@${id}").assertTextEquals("EMPTY")
+        composeContentRule.onNodeWithTag("button@${id}").performClick()
+        composeContentRule.onNodeWithTag("result@${id}").assertTextEquals(id.reversed())
+    }
+
+    private fun ActivityScenario<ComposeRecyclerViewResultActivity>.scrollTo(index: Int) {
+        onView(withId(ComposeRecyclerViewResultActivity.recyclerViewId))
+            .perform(RecyclerViewActions.scrollToPosition<ResultViewHolder>(index))
+    }
+}
+
+@Parcelize
+class ComposeRecyclerViewResultActivityKey : NavigationKey
+
+@NavigationDestination(ComposeRecyclerViewResultActivityKey::class)
+class ComposeRecyclerViewResultActivity : AppCompatActivity() {
+    private val navigation by navigationHandle<RecyclerViewResultActivityKey> {
+        defaultKey(RecyclerViewResultActivityKey())
+    }
+
+    val adapter by lazy {
+        ComposeResultTestAdapter(navigation)
+    }
+
+    val recyclerView by lazy {
+        RecyclerView(this).apply {
+            id = recyclerViewId
+            adapter = this@ComposeRecyclerViewResultActivity.adapter
+            layoutManager = LinearLayoutManager(this@ComposeRecyclerViewResultActivity)
+            itemAnimator = null
+        }
+    }
+
+    lateinit var items: List<ComposeRecyclerViewItem>
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(recyclerView)
+    }
+
+    fun setupItems(size: Int) {
+        items = List(size) { index ->
+            ComposeRecyclerViewItem(
+                id = UUID.randomUUID().toString(),
+                onResultUpdated = {
+                    result = it
+                    adapter.notifyItemChanged(index)
+                }
+            )
+        }
+        adapter.submitList(items)
+    }
+
+    companion object {
+        val recyclerViewId = View.generateViewId()
+    }
+}
+
+data class ComposeRecyclerViewItem(
+    val id: String,
+    var result: String = "EMPTY",
+    val onResultUpdated: ComposeRecyclerViewItem.(String) -> Unit,
+)
+
+class ComposeResultTestAdapter(
+    val navigationHandle: NavigationHandle
+) : ListAdapter<ComposeRecyclerViewItem, ComposeResultViewHolder>(
+    object: DiffUtil.ItemCallback<ComposeRecyclerViewItem>() {
+        override fun areItemsTheSame(oldItem: ComposeRecyclerViewItem, newItem: ComposeRecyclerViewItem): Boolean {
+            return oldItem.id == newItem.id
+        }
+
+        override fun areContentsTheSame(oldItem: ComposeRecyclerViewItem, newItem: ComposeRecyclerViewItem): Boolean {
+            return oldItem == newItem
+        }
+    }
+) {
+    var attachedViewHolderCount = 0
+        private set
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ComposeResultViewHolder {
+        return ComposeResultViewHolder(
+            ComposeView(parent.context)
+        )
+    }
+
+    override fun onViewAttachedToWindow(holder: ComposeResultViewHolder) {
+        attachedViewHolderCount++
+    }
+
+    override fun onViewDetachedFromWindow(holder: ComposeResultViewHolder) {
+        attachedViewHolderCount--
+    }
+
+    override fun onBindViewHolder(holder: ComposeResultViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+}
+
+class ComposeResultViewHolder(
+    val composeView: ComposeView,
+) : RecyclerView.ViewHolder(composeView) {
+
+    fun bind(item: ComposeRecyclerViewItem) {
+        composeView.setContent {
+            ListItemWithResult(
+                id = item.id,
+                result = item.result,
+                onResultUpdated = {
+                    item.onResultUpdated(item, it)
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun ListItemWithResult(
+    id: String,
+    result: String,
+    onResultUpdated: (String) -> Unit,
+) {
+    val channel = registerForNavigationResult<String> {
+        onResultUpdated(it)
+    }
+
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .testTag("row@$id")
+    ) {
+        Button(
+            onClick = {
+                channel.open(ImmediateSyntheticResultKey(id))
+            },
+            content = {
+                Text(text = "Get Result")
+            },
+            modifier = Modifier.testTag("button@$id")
+        )
+        Text(
+            text = result,
+            modifier = Modifier.testTag("result@$id")
+        )
+    }
+}

--- a/enro/src/androidTest/java/dev/enro/result/RecyclerViewResultTests.kt
+++ b/enro/src/androidTest/java/dev/enro/result/RecyclerViewResultTests.kt
@@ -17,6 +17,7 @@ import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.matcher.ViewMatchers.*
 import dev.enro.annotations.NavigationDestination
 import dev.enro.application
+import dev.enro.callPrivate
 import dev.enro.core.NavigationHandle
 import dev.enro.core.NavigationKey
 import dev.enro.core.controller.NavigationController
@@ -24,7 +25,6 @@ import dev.enro.core.controller.navigationController
 import dev.enro.core.navigationHandle
 import dev.enro.core.result.EnroResultChannel
 import dev.enro.core.result.registerForNavigationResult
-import dev.enro.test.callPrivate
 import kotlinx.parcelize.Parcelize
 import org.hamcrest.Matchers
 import org.junit.Assert.assertEquals

--- a/enro/src/androidTest/java/dev/enro/result/RecyclerViewResultTests.kt
+++ b/enro/src/androidTest/java/dev/enro/result/RecyclerViewResultTests.kt
@@ -1,0 +1,219 @@
+package dev.enro.result
+
+import android.os.Bundle
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.Espresso.*
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.assertion.ViewAssertions.*
+import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.*
+import dev.enro.annotations.NavigationDestination
+import dev.enro.core.NavigationHandle
+import dev.enro.core.NavigationKey
+import dev.enro.core.getNavigationHandle
+import dev.enro.core.navigationHandle
+import dev.enro.core.result.EnroResultChannel
+import dev.enro.core.result.ManagedResultChannel
+import dev.enro.core.result.registerForNavigationResult
+import dev.enro.getNavigationHandle
+import kotlinx.parcelize.Parcelize
+import org.hamcrest.Matchers
+import org.junit.Before
+import org.junit.Test
+import java.util.*
+
+
+class RecyclerViewResultTests {
+
+    @Test
+    fun whenListItemWithResultIsRenderedOnItsOwn_thenResultIsRetrievedSuccessfully() {
+        val scenario = ActivityScenario.launch(RecyclerViewResultActivity::class.java)
+        scenario.onActivity {
+            it.setupItems(1)
+        }
+        scenario.assertResultIsReceivedFor(0)
+    }
+
+    @Test
+    fun whenMultipleListItemWithResultsAreRendered_thenResultIsRetrievedSuccessfullyToTheCorrectItem() {
+        val scenario = ActivityScenario.launch(RecyclerViewResultActivity::class.java)
+        scenario.onActivity {
+            it.setupItems(5)
+        }
+
+        scenario.assertResultIsReceivedFor(0)
+        scenario.assertResultIsReceivedFor(2)
+        scenario.assertResultIsReceivedFor(4)
+    }
+
+    @Test
+    fun whenMultipleListItemWithResultsAreRenderedInRecyclerView_thenResultIsRetrievedSuccessfullyToTheCorrectItem() {
+        val scenario = ActivityScenario.launch(RecyclerViewResultActivity::class.java)
+        scenario.onActivity {
+            it.setupItems(500)
+        }
+        scenario.scrollTo(100)
+        scenario.assertResultIsReceivedFor(100)
+
+        scenario.scrollTo(460)
+        scenario.assertResultIsReceivedFor(460)
+
+        scenario.scrollTo(10)
+        scenario.assertResultIsReceivedFor(10)
+
+        scenario.scrollTo(420)
+        scenario.assertResultIsReceivedFor(420)
+
+        scenario.scrollTo(0)
+        scenario.assertResultIsReceivedFor(0)
+    }
+
+
+    private val ActivityScenario<RecyclerViewResultActivity>.items: List<RecyclerViewItem>
+        get() {
+            lateinit var items: List<RecyclerViewItem>
+            onActivity {
+                items = it.items
+            }
+            return items
+        }
+
+    private fun ActivityScenario<RecyclerViewResultActivity>.assertResultIsReceivedFor(index: Int) {
+        val id = items[index].id
+        onView(withContentDescription(Matchers.equalTo(id)))
+            .check(matches(withText("$id@EMPTY")))
+
+        onView(withContentDescription(Matchers.equalTo(id)))
+            .perform(ViewActions.click())
+
+        onView(withContentDescription(Matchers.equalTo(id)))
+            .check(matches(withText("$id@${id.reversed()}")))
+    }
+
+    private fun ActivityScenario<RecyclerViewResultActivity>.scrollTo(index: Int) {
+        onView(withId(RecyclerViewResultActivity.recyclerViewId))
+            .perform(RecyclerViewActions.scrollToPosition<ResultViewHolder>(index))
+    }
+}
+
+@Parcelize
+class RecyclerViewResultActivityKey : NavigationKey
+
+@NavigationDestination(RecyclerViewResultActivityKey::class)
+class RecyclerViewResultActivity : AppCompatActivity() {
+    private val navigation by navigationHandle<RecyclerViewResultActivityKey> {
+        defaultKey(RecyclerViewResultActivityKey())
+    }
+
+    val adapter: ListAdapter<RecyclerViewItem, *> by lazy {
+        ResultTestAdapter(navigation)
+    }
+
+    val recyclerView by lazy {
+        RecyclerView(this).apply {
+            id = recyclerViewId
+            adapter = this@RecyclerViewResultActivity.adapter
+            layoutManager = LinearLayoutManager(this@RecyclerViewResultActivity)
+            itemAnimator = null
+        }
+    }
+
+    var items: List<RecyclerViewItem>
+        get() = adapter.currentList
+        private set(value) = adapter.submitList(value)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(recyclerView)
+    }
+
+    fun setupItems(size: Int) {
+        items = List(size) { index ->
+            RecyclerViewItem(
+                id = UUID.randomUUID().toString(),
+                onResultUpdated = { updateItem(index, it) }
+            )
+        }
+    }
+
+    fun updateItem(index: Int, result: String) {
+        items = items.mapIndexed { i, item ->
+            if(index == i) {
+                item.copy(
+                    result = result
+                )
+            }
+            else item
+        }
+    }
+
+    companion object {
+        val recyclerViewId = View.generateViewId()
+    }
+}
+
+data class RecyclerViewItem(
+    val id: String,
+    val result: String = "EMPTY",
+    val onResultUpdated: (String) -> Unit,
+)
+
+private class ResultTestAdapter(
+    val navigationHandle: NavigationHandle
+) : ListAdapter<RecyclerViewItem, ResultViewHolder>(
+    object: DiffUtil.ItemCallback<RecyclerViewItem>() {
+        override fun areItemsTheSame(oldItem: RecyclerViewItem, newItem: RecyclerViewItem): Boolean {
+            return oldItem.id == newItem.id
+        }
+
+        override fun areContentsTheSame(oldItem: RecyclerViewItem, newItem: RecyclerViewItem): Boolean {
+            return oldItem == newItem
+        }
+    }
+) {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ResultViewHolder {
+        return ResultViewHolder(
+            textView = TextView(parent.context).apply {
+                setPadding(
+                    30, 30, 30, 30
+                )
+            },
+            navigationHandle = navigationHandle
+        )
+    }
+
+    override fun onBindViewHolder(holder: ResultViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+}
+
+private class ResultViewHolder(
+    val textView: TextView,
+    val navigationHandle: NavigationHandle
+) : RecyclerView.ViewHolder(textView) {
+
+    private var channel: EnroResultChannel<String>? = null
+
+    fun bind(item: RecyclerViewItem) {
+        channel = navigationHandle.registerForNavigationResult<String> {
+            item.onResultUpdated(it)
+        }
+
+        textView.contentDescription = item.id
+        textView.text = "${item.id}@${item.result}"
+        textView.setOnClickListener {
+            channel?.open(ImmediateSyntheticResultKey(item.id))
+        }
+    }
+}

--- a/enro/src/androidTest/java/dev/enro/result/RecyclerViewResultTests.kt
+++ b/enro/src/androidTest/java/dev/enro/result/RecyclerViewResultTests.kt
@@ -247,13 +247,3 @@ class ResultViewHolder(
         }
     }
 }
-
-private fun getActiveEnroResultChannels(): List<EnroResultChannel<*>> {
-    val enroResultClass = Class.forName("dev.enro.core.result.EnroResult")
-    val getEnroResult = enroResultClass.getDeclaredMethod("from", NavigationController::class.java)
-    getEnroResult.isAccessible = true
-    val enroResult = getEnroResult.invoke(null, application.navigationController)
-    getEnroResult.isAccessible = false
-
-    return enroResult.callPrivate("getActiveChannelsForTest")
-}

--- a/settings.gradle
+++ b/settings.gradle
@@ -66,6 +66,7 @@ dependencyResolutionManagement {
             alias("testing-androidx-core").to("androidx.test:core:1.4.0")
             alias("testing-androidx-runner").to("androidx.test:runner:1.4.0")
             alias("testing-androidx-espresso").to("androidx.test.espresso:espresso-core:3.4.0")
+            alias("testing-androidx-espressoRecyclerView").to("androidx.test.espresso:espresso-contrib:3.4.0")
             alias("testing-androidx-espressoIntents").to("androidx.test.espresso:espresso-intents:3.4.0")
             alias("testing-androidx-fragment").to("androidx.fragment:fragment-testing:1.4.1")
             alias("testing-androidx-compose").to("androidx.compose.ui:ui-test-junit4:1.1.0")


### PR DESCRIPTION
The registerForNavigationResult functions are not able to be used from outside of Activities/Fragments, but there is no reason for this restriction. A non-lazy version of registerForNavigationResult that directly returns a result channel (rather than a lazy property) has been added to live alongside the lazy versions of these properties. 

Using registerForNavigationResult inside lists does not work correctly when there are multiple UI elements that are attempting to register for the result. This issue affected Compose before the  changes to registerForNavigationResult, and affects the legacy View system now that registerForNavigationResult is available outside of Activities and Fragments. This issue has been resolved, and tests have been added to ensure that there will be no regressions. 