### PR TITLE
Update for Androidx Lifecycle 2.8.0 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added extensions for `findContext` and `findActiveContext` to `NavigationContext` to allow for finding other NavigationContexts from a context reference
 * Updated `NavigationContainer` to add `getChildContext` which allows finding specific Active/ActivePushed/ActivePresented/Specific contexts from a container reference
 * Added `instruction` property to `NavigationContext`, and marked `NavigationContext` as `@AdvancedEnroApi`
+* Added support for androidx.lifecycle `2.8.0-beta01` and the removal of setTagIfAbsent/getTag (will use addCloseable/getCloseable if it is possible)
 
 ## 2.3.0
 * Updated NavigationFlow to return from `next` after `onCompleted` is called, rather than continuing to set the backstack from the flow

--- a/enro-core/src/main/java/androidx/lifecycle/SetNavigationHandle.kt
+++ b/enro-core/src/main/java/androidx/lifecycle/SetNavigationHandle.kt
@@ -1,19 +1,30 @@
 package androidx.lifecycle
 
 import dev.enro.core.NavigationHandle
-
+import java.io.Closeable
 
 internal const val NAVIGATION_HANDLE_KEY = "dev.enro.viemodel.NAVIGATION_HANDLE_KEY"
 
+internal class ClosableNavigationHandleReference(
+    navigationHandle: NavigationHandle,
+) : Closeable {
+    var navigationHandle: NavigationHandle? = navigationHandle
+    override fun close() {
+        navigationHandle = null
+    }
+}
+
 internal fun ViewModel.setNavigationHandleTag(navigationHandle: NavigationHandle) {
-    setTagIfAbsent(
+    addCloseable(
         NAVIGATION_HANDLE_KEY,
-        navigationHandle
+        ClosableNavigationHandleReference(navigationHandle),
     )
+
 }
 
 internal fun ViewModel.getNavigationHandleTag(): NavigationHandle? {
-    return getTag<NavigationHandle>(
+    val closeable = getCloseable(
         NAVIGATION_HANDLE_KEY
-    )
+    ) as? ClosableNavigationHandleReference
+    return closeable?.navigationHandle
 }

--- a/enro-core/src/main/java/dev/enro/android/viewmodel/EnroViewModelFactory.kt
+++ b/enro-core/src/main/java/dev/enro/android/viewmodel/EnroViewModelFactory.kt
@@ -4,8 +4,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.setNavigationHandleTag
 import androidx.lifecycle.viewmodel.CreationExtras
+import androidx.lifecycle.viewmodel.MutableCreationExtras
 import dev.enro.core.EnroException
 import dev.enro.core.NavigationHandle
+import kotlin.reflect.KClass
 
 @PublishedApi
 internal class EnroViewModelFactory(
@@ -13,11 +15,15 @@ internal class EnroViewModelFactory(
     private val delegate: ViewModelProvider.Factory
 ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
+        val mutableCreationExtras = MutableCreationExtras(extras)
         EnroViewModelNavigationHandleProvider.put(modelClass, navigationHandle)
         val viewModel = try {
-            delegate.create(modelClass, extras) as T
+            if (mutableCreationExtras[ViewModelProvider.NewInstanceFactory.VIEW_MODEL_KEY] == null) {
+                mutableCreationExtras[ViewModelProvider.NewInstanceFactory.VIEW_MODEL_KEY] = getDefaultKey(modelClass.kotlin)
+            }
+            delegate.create(modelClass, mutableCreationExtras) as T
         } catch (ex: RuntimeException) {
-            if(ex is EnroException) throw ex
+            if (ex is EnroException) throw ex
             throw EnroException.CouldNotCreateEnroViewModel(
                 "Failed to created ${modelClass.name} using factory ${delegate::class.java.name}.\n",
                 ex
@@ -30,5 +36,20 @@ internal class EnroViewModelFactory(
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         return create(modelClass, CreationExtras.Empty)
+    }
+
+    companion object {
+        /**
+         * See [androidx.lifecycle.viewmodel.internal.ViewModelProviders]
+         */
+        private const val VIEW_MODEL_PROVIDER_DEFAULT_KEY: String =
+            "androidx.lifecycle.ViewModelProvider.DefaultKey"
+
+        internal fun <T : ViewModel> getDefaultKey(modelClass: KClass<T>): String {
+            val canonicalName = requireNotNull(modelClass.qualifiedName) {
+                "Local and anonymous classes can not be ViewModels"
+            }
+            return "${VIEW_MODEL_PROVIDER_DEFAULT_KEY}:$canonicalName"
+        }
     }
 }

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -18,9 +18,9 @@ androidx-navigation-ui = "androidx.navigation:navigation-ui-ktx:2.7.7"
 androidx-activity = "androidx.activity:activity-ktx:1.9.0"
 compose-activity = "androidx.activity:activity-compose:1.9.0"
 
-androidx-lifecycle = "androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0"
-androidx-lifecycle-process = "androidx.lifecycle:lifecycle-process:2.7.0"
-compose-viewmodel = "androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0"
+androidx-lifecycle = "androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.0-beta01"
+androidx-lifecycle-process = "androidx.lifecycle:lifecycle-process:2.8.0-beta01"
+compose-viewmodel = "androidx.lifecycle:lifecycle-viewmodel-compose:2.8.0-beta01"
 
 compose-compiler = "androidx.compose.compiler:compiler:1.5.12"
 compose-foundation = "androidx.compose.foundation:foundation:1.6.6"


### PR DESCRIPTION
AndroidX Lifecycle 2.8.0 has some changes to ViewModel functionality that is being used by Enro, so some changes to the library are required.