### PR TITLE
Add @NavigationPath.FromBinding and value class path parameter support

### DIFF
--- a/enro-annotations/src/commonMain/kotlin/dev/enro/annotations/NavigationPath.kt
+++ b/enro-annotations/src/commonMain/kotlin/dev/enro/annotations/NavigationPath.kt
@@ -1,9 +1,29 @@
 package dev.enro.annotations
 
+import kotlin.reflect.KClass
+
 
 @Retention(AnnotationRetention.BINARY)
 @Target(AnnotationTarget.CLASS, AnnotationTarget.CONSTRUCTOR)
 @ExperimentalEnroApi
 public annotation class NavigationPath(
     val pattern: String,
-)
+) {
+    /**
+     * Declares that a [NavigationKey][dev.enro.NavigationKey] is bound to a path via a
+     * user-implemented `NavigationKey.PathBinding<T>`. Use this for cases that don't
+     * fit the simple property-based mapping provided by the parent [NavigationPath]
+     * annotation — for example, when some properties get default values that aren't
+     * present in the URL, or when the deserialize/serialize logic needs to be hand-written.
+     *
+     * The referenced [binding] must be a class (typically a nested `object` on the key
+     * class) that implements `dev.enro.NavigationKey.PathBinding<T>` where `T` is the
+     * key type itself.
+     */
+    @Retention(AnnotationRetention.BINARY)
+    @Target(AnnotationTarget.CLASS)
+    @ExperimentalEnroApi
+    public annotation class FromBinding(
+        val binding: KClass<out Any>,
+    )
+}

--- a/enro-common/src/commonMain/kotlin/dev/enro/NavigationKey.kt
+++ b/enro-common/src/commonMain/kotlin/dev/enro/NavigationKey.kt
@@ -3,6 +3,8 @@ package dev.enro
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import dev.enro.annotations.AdvancedEnroApi
+import dev.enro.annotations.ExperimentalEnroApi
+import dev.enro.path.PathData
 import dev.enro.serialization.internalUnwrapForSerialization
 import dev.enro.serialization.internalWrapForSerialization
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -52,6 +54,23 @@ public interface NavigationKey {
      * to return a typed value to its caller, enabling type-safe result handling.
      */
     public interface WithResult<T: Any> : NavigationKey
+
+    /**
+     * Describes how to convert between a URL-style path string and an instance of a
+     * [NavigationKey] of type [T]. Implement this interface (typically as a nested
+     * `object` on the key class) and reference it from
+     * [dev.enro.annotations.NavigationPath.FromBinding] for cases that don't fit the
+     * simple property-based mapping driven by [dev.enro.annotations.NavigationPath].
+     *
+     * The [pattern] follows the standard Enro path-pattern grammar
+     * (e.g. `"/users/{id}?source={source?}"`).
+     */
+    @ExperimentalEnroApi
+    public interface PathBinding<T : NavigationKey> {
+        public val pattern: String
+        public fun deserialize(data: PathData): T
+        public fun serialize(builder: PathData.Builder, key: T)
+    }
 
     /**
      * A data class that bundles a [key] of type [T] with its associated [metadata].

--- a/enro-common/src/commonMain/kotlin/dev/enro/path/NavigationPathBinding.fromNavigationKey.kt
+++ b/enro-common/src/commonMain/kotlin/dev/enro/path/NavigationPathBinding.fromNavigationKey.kt
@@ -1,8 +1,30 @@
 package dev.enro.path
 
 import dev.enro.NavigationKey
+import dev.enro.annotations.ExperimentalEnroApi
+import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
 import kotlin.reflect.typeOf
+
+/**
+ * Wraps a user-implemented [NavigationKey.PathBinding] into a runtime
+ * [NavigationPathBinding] that can be registered on a [dev.enro.controller.NavigationModule].
+ *
+ * Used by code generated for `@NavigationPath.FromBinding(MyBinding::class)`, but also
+ * usable directly from hand-written modules.
+ */
+@OptIn(ExperimentalEnroApi::class)
+public fun <T : NavigationKey> NavigationPathBinding.Companion.fromBinding(
+    keyType: KClass<T>,
+    binding: NavigationKey.PathBinding<T>,
+): NavigationPathBinding<T> {
+    return NavigationPathBinding(
+        keyType = keyType,
+        pattern = binding.pattern,
+        deserialize = { binding.deserialize(this) },
+        serialize = { key -> binding.serialize(this, key) },
+    )
+}
 
 @PublishedApi
 internal inline fun <reified P> checkParameterIsSupported(

--- a/enro-common/src/commonMain/kotlin/dev/enro/path/NavigationPathBinding.kt
+++ b/enro-common/src/commonMain/kotlin/dev/enro/path/NavigationPathBinding.kt
@@ -30,13 +30,6 @@ public class NavigationPathBinding<T : NavigationKey> @PublishedApi internal con
         return keyType.isInstance(key)
     }
 
-    /**
-     * How specific this binding's pattern is. When multiple bindings [matches] the
-     * same path, [getPathBinding][dev.enro.controller.repository.PathRepository.getPathBinding]
-     * picks the one with the highest specificity. Higher = more specific.
-     */
-    public val specificity: Int get() = pattern.specificityScore
-
     public fun fromPath(path: ParsedPath): T {
         if (!matches(path)) {
             throw IllegalArgumentException("Path does not match the pattern")
@@ -51,5 +44,29 @@ public class NavigationPathBinding<T : NavigationKey> @PublishedApi internal con
         return pattern.toPath(builder.build())
     }
 
-    public companion object
+    public companion object {
+        /**
+         * Picks the most specific binding from [bindings] that [matches][NavigationPathBinding.matches]
+         * [path]. When multiple bindings match, more literal path segments wins, then more
+         * required query parameters.
+         *
+         * Returns `null` when no binding matches; throws when the top-scoring set is
+         * itself ambiguous (multiple bindings tied at the most-specific score).
+         */
+        public fun resolveForPath(
+            bindings: List<NavigationPathBinding<*>>,
+            path: ParsedPath,
+        ): NavigationPathBinding<*>? {
+            val matching = bindings.filter { it.matches(path) }
+            if (matching.isEmpty()) return null
+            if (matching.size == 1) return matching.single()
+
+            val topScore = matching.maxOf { it.pattern.specificityScore }
+            val mostSpecific = matching.filter { it.pattern.specificityScore == topScore }
+            require(mostSpecific.size == 1) {
+                "Multiple path bindings found for path: $path"
+            }
+            return mostSpecific.single()
+        }
+    }
 }

--- a/enro-common/src/commonMain/kotlin/dev/enro/path/NavigationPathBinding.kt
+++ b/enro-common/src/commonMain/kotlin/dev/enro/path/NavigationPathBinding.kt
@@ -30,6 +30,13 @@ public class NavigationPathBinding<T : NavigationKey> @PublishedApi internal con
         return keyType.isInstance(key)
     }
 
+    /**
+     * How specific this binding's pattern is. When multiple bindings [matches] the
+     * same path, [getPathBinding][dev.enro.controller.repository.PathRepository.getPathBinding]
+     * picks the one with the highest specificity. Higher = more specific.
+     */
+    public val specificity: Int get() = pattern.specificityScore
+
     public fun fromPath(path: ParsedPath): T {
         if (!matches(path)) {
             throw IllegalArgumentException("Path does not match the pattern")

--- a/enro-common/src/commonMain/kotlin/dev/enro/path/NavigationPathBinding.kt
+++ b/enro-common/src/commonMain/kotlin/dev/enro/path/NavigationPathBinding.kt
@@ -26,6 +26,10 @@ public class NavigationPathBinding<T : NavigationKey> @PublishedApi internal con
         return pattern.matches(path)
     }
 
+    public fun matches(key: NavigationKey): Boolean {
+        return keyType.isInstance(key)
+    }
+
     public fun fromPath(path: ParsedPath): T {
         if (!matches(path)) {
             throw IllegalArgumentException("Path does not match the pattern")

--- a/enro-common/src/commonMain/kotlin/dev/enro/path/PathData.kt
+++ b/enro-common/src/commonMain/kotlin/dev/enro/path/PathData.kt
@@ -1,14 +1,16 @@
 package dev.enro.path
 
-public class PathData(
-    internal val data: MutableMap<String, String> = mutableMapOf(),
+public class PathData internal constructor(
+    internal val data: Map<String, String>,
 ) {
     public fun optional(key: String): String? {
         return data[key]
     }
 
     public fun require(key: String): String {
-        return requireNotNull(data[key])
+        return requireNotNull(data[key]) {
+            "No value found for path parameter '$key'"
+        }
     }
 
     public class Builder internal constructor() {
@@ -19,7 +21,7 @@ public class PathData(
         }
 
         internal fun build(): PathData {
-            return PathData(data)
+            return PathData(data.toMap())
         }
     }
 }

--- a/enro-common/src/commonMain/kotlin/dev/enro/path/PathPattern.kt
+++ b/enro-common/src/commonMain/kotlin/dev/enro/path/PathPattern.kt
@@ -32,6 +32,18 @@ internal data class PathPattern(
         return true
     }
 
+    /**
+     * A specificity score used to disambiguate between multiple bindings that all
+     * [matches] the same path. Higher is more specific. Literal path segments dominate
+     * (weighted ahead of query params), then required query parameters.
+     */
+    internal val specificityScore: Int
+        get() {
+            val literalSegments = pathElements.count { it is PathElement.Segment }
+            val requiredQueryParams = queryElements.count { it is QueryElement.QueryParam }
+            return literalSegments * 1_000 + requiredQueryParams
+        }
+
     fun toPathData(parsedPath: ParsedPath): PathData {
         val data = mutableMapOf<String, String>()
         for (i in pathElements.indices) {

--- a/enro-processor/src/main/java/dev/enro/processor/generator/NavigationBindingGenerator.kt
+++ b/enro-processor/src/main/java/dev/enro/processor/generator/NavigationBindingGenerator.kt
@@ -1,19 +1,25 @@
 package dev.enro.processor.generator
 
 import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.getAllSuperTypes
 import com.google.devtools.ksp.getAnnotationsByType
 import com.google.devtools.ksp.getConstructors
 import com.google.devtools.ksp.processing.Dependencies
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.symbol.ClassKind
+import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.Modifier
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.toTypeName
@@ -97,6 +103,7 @@ object NavigationBindingGenerator {
             .addImport("dev.enro.ui", "navigationDestination")
             .addImport("dev.enro.path", "NavigationPathBinding")
             .addImport("dev.enro.path", "createPathBinding")
+            .addImport("dev.enro.path", "fromBinding")
             .apply {
                 when {
                     destination.isActivity -> addImport("dev.enro.ui.destinations", "activityDestination")
@@ -200,39 +207,376 @@ object NavigationBindingGenerator {
             )
             .toList()
 
-        if (navigationPaths.isEmpty()) return this
         navigationPaths.forEach { (path, constructor) ->
             val pattern = path.pattern
-            val constructorReference = when {
-                constructor == null -> "{ %T }"
-                else -> { "::%T" }
-            }
-
-            addCode("\n")
             val params = pathPatternToParameterNames(pattern)
 
-            val typeName = destination.keyType.asStarProjectedType().toTypeName()
-            val paramTypeArray = params.map { typeName }.toTypedArray()
-            val paramReferences = params.map { "%T::$it" }.joinToString("\n") {
-                "                        $it,"
+            val hasValueClassParam = constructor != null && constructor.parameters.any { param ->
+                val paramName = param.name?.asString() ?: return@any false
+                if (paramName !in params) return@any false
+                param.type.resolve().declaration.isValueClass()
+            }
+            val exceedsHelperArity = params.size > 8
+
+            if (constructor != null && (hasValueClassParam || exceedsHelperArity)) {
+                addExplicitPathBinding(environment, destination, pattern, constructor)
+            } else {
+                addHelperPathBinding(destination, pattern, constructor)
+            }
+        }
+
+        addFromBindingPaths(environment, destination)
+        return this
+    }
+
+    @OptIn(KspExperimental::class)
+    private fun FunSpec.Builder.addFromBindingPaths(
+        environment: SymbolProcessorEnvironment,
+        destination: DestinationReference,
+    ): FunSpec.Builder {
+        val fromBindingAnnotations = destination.keyType.annotations
+            .filter { annotation ->
+                annotation.annotationType.resolve().declaration.qualifiedName?.asString() ==
+                    "dev.enro.annotations.NavigationPath.FromBinding"
+            }
+            .toList()
+
+        if (fromBindingAnnotations.isEmpty()) return this
+
+        val pathBindingFqn = "dev.enro.NavigationKey.PathBinding"
+
+        fromBindingAnnotations.forEach { annotation ->
+            val bindingTypeArg = annotation.arguments
+                .firstOrNull { it.name?.asString() == "binding" }
+                ?.value as? KSType
+            val bindingDecl = bindingTypeArg?.declaration as? KSClassDeclaration
+            if (bindingDecl == null) {
+                environment.logger.error(
+                    "@NavigationPath.FromBinding could not resolve binding class on ${destination.keyType.qualifiedName?.asString()}",
+                    destination.declaration,
+                )
+                return@forEach
             }
 
-            addCode(
+            if (bindingDecl.classKind != ClassKind.OBJECT) {
+                environment.logger.error(
+                    "@NavigationPath.FromBinding referenced class '${bindingDecl.qualifiedName?.asString()}' must be an object (singleton).",
+                    bindingDecl,
+                )
+                return@forEach
+            }
+
+            val implementsPathBinding = bindingDecl.getAllSuperTypes().any { superType ->
+                val decl = superType.declaration
+                if (decl.qualifiedName?.asString() != pathBindingFqn) return@any false
+                val typeArg = superType.arguments.firstOrNull()?.type?.resolve()
+                typeArg?.declaration?.qualifiedName?.asString() ==
+                    destination.keyType.qualifiedName?.asString()
+            }
+            if (!implementsPathBinding) {
+                environment.logger.error(
+                    "@NavigationPath.FromBinding referenced class '${bindingDecl.qualifiedName?.asString()}' " +
+                        "must implement NavigationKey.PathBinding<${destination.keyType.qualifiedName?.asString()}>.",
+                    bindingDecl,
+                )
+                return@forEach
+            }
+
+            val formatting = LinkedHashMap<String, Any>()
+            formatting["keyType"] = destination.keyType.toClassName()
+            formatting["binding"] = bindingDecl.toClassName()
+
+            addCode("\n")
+            addNamedCode(
                 """
                 path(
-                    NavigationPathBinding.createPathBinding(
-                        pattern = %S,${"\n"}$paramReferences
-                        constructor = $constructorReference
+                    NavigationPathBinding.fromBinding(
+                        keyType = %keyType:T::class,
+                        binding = %binding:T,
                     )
                 )
                """.trimIndent(),
-                pattern,
-                *paramTypeArray,
-                typeName,
+                formatting,
             )
         }
         return this
     }
+
+    private fun FunSpec.Builder.addHelperPathBinding(
+        destination: DestinationReference,
+        pattern: String,
+        constructor: KSFunctionDeclaration?,
+    ): FunSpec.Builder {
+        val constructorReference = when {
+            constructor == null -> "{ %T }"
+            else -> "::%T"
+        }
+
+        addCode("\n")
+        val params = pathPatternToParameterNames(pattern)
+
+        val typeName = destination.keyType.asStarProjectedType().toTypeName()
+        val paramTypeArray = params.map { typeName }.toTypedArray()
+        val paramReferences = params.map { "%T::$it" }.joinToString("\n") {
+            "                        $it,"
+        }
+
+        addCode(
+            """
+            path(
+                NavigationPathBinding.createPathBinding(
+                    pattern = %S,${"\n"}$paramReferences
+                    constructor = $constructorReference
+                )
+            )
+           """.trimIndent(),
+            pattern,
+            *paramTypeArray,
+            typeName,
+        )
+        return this
+    }
+
+    private fun FunSpec.Builder.addExplicitPathBinding(
+        environment: SymbolProcessorEnvironment,
+        destination: DestinationReference,
+        pattern: String,
+        constructor: KSFunctionDeclaration,
+    ): FunSpec.Builder {
+        val patternParams = pathPatternToParameterNames(pattern)
+        val optionalParams = pathPatternToOptionalParameterNames(pattern)
+        val keyTypeName = destination.keyType.toClassName()
+
+        // Resolve each pattern param to its constructor param + serialization shape.
+        val resolved = patternParams.mapNotNull { paramName ->
+            val ksParam = constructor.parameters.firstOrNull { it.name?.asString() == paramName }
+            if (ksParam == null) {
+                environment.logger.error(
+                    "Path pattern parameter '$paramName' does not match any parameter on the annotated constructor of ${destination.keyType.qualifiedName?.asString()}",
+                    constructor,
+                )
+                return@mapNotNull null
+            }
+            val ksType = ksParam.type.resolve()
+            val isOptional = paramName in optionalParams
+            val nullable = ksType.isMarkedNullable
+            if (nullable != isOptional) {
+                environment.logger.error(
+                    "Path pattern parameter '$paramName' is ${if (isOptional) "optional" else "required"}, " +
+                        "but constructor parameter is ${if (nullable) "nullable" else "non-nullable"}",
+                    ksParam,
+                )
+                return@mapNotNull null
+            }
+            val shape = resolvePathParamShape(environment, ksType, ksParam)
+                ?: return@mapNotNull null
+            ResolvedPathParam(paramName, shape, nullable)
+        }
+        if (resolved.size != patternParams.size) return this
+
+        // Build deserialize body: K(p1 = ..., p2 = ...)
+        // Build serialize body: set(...), key.x?.let { ... }
+        val deserializeLines = mutableListOf<String>()
+        val serializeLines = mutableListOf<String>()
+        val codeArgs = mutableListOf<Any>()
+
+        deserializeLines.add("%keyType:T(")
+        resolved.forEachIndexed { index, p ->
+            val deserializeExpr = buildDeserializeExpr(p, codeArgs)
+            deserializeLines.add("    ${p.name} = $deserializeExpr,")
+            val serializeStmt = buildSerializeStmt(p, codeArgs)
+            serializeLines.add(serializeStmt)
+        }
+        deserializeLines.add(")")
+
+        val deserializeBody = deserializeLines.joinToString("\n                            ")
+        val serializeBody = serializeLines.joinToString("\n                        ")
+
+        val formatting = LinkedHashMap<String, Any>()
+        formatting["keyType"] = keyTypeName
+        formatting["pattern"] = pattern
+        codeArgs.forEachIndexed { i, value -> formatting["arg$i"] = value }
+
+        addCode("\n")
+        addNamedCode(
+            """
+            path(
+                NavigationPathBinding(
+                    keyType = %keyType:T::class,
+                    pattern = %pattern:S,
+                    deserialize = {
+                        $deserializeBody
+                    },
+                    serialize = {
+                        $serializeBody
+                    },
+                )
+            )
+           """.trimIndent(),
+            formatting,
+        )
+        return this
+    }
+}
+
+private data class PathParamShape(
+    val primitiveFqn: String,
+    val valueClassTypeName: TypeName?,
+    val valueClassUnderlyingPropertyName: String?,
+)
+
+private data class ResolvedPathParam(
+    val name: String,
+    val shape: PathParamShape,
+    val isNullable: Boolean,
+)
+
+private fun resolvePathParamShape(
+    environment: SymbolProcessorEnvironment,
+    ksType: KSType,
+    sourceSymbol: com.google.devtools.ksp.symbol.KSNode,
+): PathParamShape? {
+    val decl = ksType.declaration
+    val primitiveFqn = decl.qualifiedName?.asString()
+    if (primitiveFqn in SUPPORTED_PRIMITIVE_FQNS) {
+        return PathParamShape(
+            primitiveFqn = primitiveFqn!!,
+            valueClassTypeName = null,
+            valueClassUnderlyingPropertyName = null,
+        )
+    }
+    if (!decl.isValueClass()) {
+        environment.logger.error(
+            "Path parameter type '${primitiveFqn ?: decl.simpleName.asString()}' is not supported. " +
+                "Must be a primitive (String, Int, Long, Float, Double, Short, Byte, Char, Boolean) " +
+                "or a value class wrapping one of those primitives.",
+            sourceSymbol,
+        )
+        return null
+    }
+    val valueClass = decl as KSClassDeclaration
+    val underlyingParam = valueClass.primaryConstructor?.parameters?.singleOrNull()
+    if (underlyingParam == null) {
+        environment.logger.error(
+            "Value class '${valueClass.qualifiedName?.asString()}' must have exactly one constructor parameter to be used as a path parameter.",
+            sourceSymbol,
+        )
+        return null
+    }
+    val underlyingType = underlyingParam.type.resolve()
+    if (underlyingType.isMarkedNullable) {
+        environment.logger.error(
+            "Value class '${valueClass.qualifiedName?.asString()}' wraps a nullable type, which is not supported for path parameters.",
+            sourceSymbol,
+        )
+        return null
+    }
+    val underlyingFqn = underlyingType.declaration.qualifiedName?.asString()
+    if (underlyingFqn !in SUPPORTED_PRIMITIVE_FQNS) {
+        environment.logger.error(
+            "Value class '${valueClass.qualifiedName?.asString()}' wraps unsupported type '$underlyingFqn'. " +
+                "Only value classes wrapping a primitive (String, Int, Long, Float, Double, Short, Byte, Char, Boolean) are supported.",
+            sourceSymbol,
+        )
+        return null
+    }
+    return PathParamShape(
+        primitiveFqn = underlyingFqn!!,
+        valueClassTypeName = valueClass.toClassName(),
+        valueClassUnderlyingPropertyName = underlyingParam.name?.asString(),
+    )
+}
+
+private fun buildDeserializeExpr(
+    param: ResolvedPathParam,
+    codeArgs: MutableList<Any>,
+): String {
+    val accessor = if (param.isNullable) {
+        "optional(\"${param.name}\")"
+    } else {
+        "require(\"${param.name}\")"
+    }
+    val converted = primitiveParseExpression(param.shape.primitiveFqn, accessor, param.isNullable)
+    return if (param.shape.valueClassTypeName != null) {
+        codeArgs.add(param.shape.valueClassTypeName)
+        val placeholder = "%arg${codeArgs.size - 1}:T"
+        if (param.isNullable) {
+            "$converted?.let { $placeholder(it) }"
+        } else {
+            "$placeholder($converted)"
+        }
+    } else {
+        converted
+    }
+}
+
+private fun buildSerializeStmt(
+    param: ResolvedPathParam,
+    codeArgs: MutableList<Any>,
+): String {
+    val unwrap = if (param.shape.valueClassUnderlyingPropertyName != null) {
+        "v.${param.shape.valueClassUnderlyingPropertyName}"
+    } else {
+        "v"
+    }
+    val stringified = if (param.shape.primitiveFqn == "kotlin.String") unwrap else "$unwrap.toString()"
+    return if (param.isNullable) {
+        "it.${param.name}?.let { v -> set(\"${param.name}\", $stringified) }"
+    } else {
+        val nonNullSource = if (param.shape.valueClassUnderlyingPropertyName != null) {
+            "it.${param.name}.${param.shape.valueClassUnderlyingPropertyName}"
+        } else {
+            "it.${param.name}"
+        }
+        val nonNullStringified = if (param.shape.primitiveFqn == "kotlin.String") nonNullSource else "$nonNullSource.toString()"
+        "set(\"${param.name}\", $nonNullStringified)"
+    }
+}
+
+private fun primitiveParseExpression(
+    primitiveFqn: String,
+    source: String,
+    isNullable: Boolean,
+): String {
+    val nullableSuffix = if (isNullable) "?" else ""
+    return when (primitiveFqn) {
+        "kotlin.String" -> source
+        "kotlin.Int" -> "$source$nullableSuffix.toInt()"
+        "kotlin.Long" -> "$source$nullableSuffix.toLong()"
+        "kotlin.Float" -> "$source$nullableSuffix.toFloat()"
+        "kotlin.Double" -> "$source$nullableSuffix.toDouble()"
+        "kotlin.Short" -> "$source$nullableSuffix.toShort()"
+        "kotlin.Byte" -> "$source$nullableSuffix.toByte()"
+        "kotlin.Char" -> "$source$nullableSuffix.first()"
+        "kotlin.Boolean" -> "$source$nullableSuffix.toBoolean()"
+        else -> error("Unsupported primitive: $primitiveFqn")
+    }
+}
+
+private fun KSDeclaration.isValueClass(): Boolean {
+    return this is KSClassDeclaration && Modifier.VALUE in modifiers
+}
+
+private val SUPPORTED_PRIMITIVE_FQNS = setOf(
+    "kotlin.String",
+    "kotlin.Int",
+    "kotlin.Long",
+    "kotlin.Float",
+    "kotlin.Double",
+    "kotlin.Short",
+    "kotlin.Byte",
+    "kotlin.Char",
+    "kotlin.Boolean",
+)
+
+private fun pathPatternToOptionalParameterNames(pattern: String): Set<String> {
+    val split = pattern.split("?", limit = 2)
+    val query = split.getOrNull(1) ?: return emptySet()
+    return query.split("&")
+        .mapNotNull { it.split("=", limit = 2).getOrNull(1) }
+        .filter { it.startsWith("{") && it.endsWith("?}") }
+        .map { it.removePrefix("{").removeSuffix("?}") }
+        .toSet()
 }
 
 private fun pathPatternToParameterNames(pattern: String): List<String> {

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/controller/repository/PathRepository.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/controller/repository/PathRepository.kt
@@ -21,16 +21,7 @@ public class PathRepository {
     }
 
     public fun getPathBinding(path: ParsedPath): NavigationPathBinding<*>? {
-        val matching = bindings.filter { it.matches(path) }
-        if (matching.isEmpty()) return null
-        if (matching.size == 1) return matching.single()
-
-        val topScore = matching.maxOf { it.specificity }
-        val mostSpecific = matching.filter { it.specificity == topScore }
-        require(mostSpecific.size == 1) {
-            "Multiple path bindings found for path: $path"
-        }
-        return mostSpecific.single()
+        return NavigationPathBinding.resolveForPath(bindings, path)
     }
 
     public fun <T : NavigationKey> getPathBindingForKey(key: T): NavigationPathBinding<T>? {

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/controller/repository/PathRepository.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/controller/repository/PathRepository.kt
@@ -23,10 +23,14 @@ public class PathRepository {
     public fun getPathBinding(path: ParsedPath): NavigationPathBinding<*>? {
         val matching = bindings.filter { it.matches(path) }
         if (matching.isEmpty()) return null
-        require(matching.size == 1) {
+        if (matching.size == 1) return matching.single()
+
+        val topScore = matching.maxOf { it.specificity }
+        val mostSpecific = matching.filter { it.specificity == topScore }
+        require(mostSpecific.size == 1) {
             "Multiple path bindings found for path: $path"
         }
-        return matching.single()
+        return mostSpecific.single()
     }
 
     public fun <T : NavigationKey> getPathBindingForKey(key: T): NavigationPathBinding<T>? {

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/controller/repository/PathRepository.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/controller/repository/PathRepository.kt
@@ -28,4 +28,13 @@ public class PathRepository {
         }
         return matching.single()
     }
+
+    public fun <T : NavigationKey> getPathBindingForKey(key: T): NavigationPathBinding<T>? {
+        @Suppress("UNCHECKED_CAST")
+        return bindings.firstOrNull { it.matches(key) } as NavigationPathBinding<T>?
+    }
+
+    public fun getPathBindingsForKey(key: NavigationKey): List<NavigationPathBinding<*>> {
+        return bindings.filter { it.matches(key) }
+    }
 }

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/path/EnroController.getNavigationKeyFromPath.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/path/EnroController.getNavigationKeyFromPath.kt
@@ -1,0 +1,17 @@
+package dev.enro.path
+
+import dev.enro.EnroController
+import dev.enro.NavigationKey
+import dev.enro.annotations.ExperimentalEnroApi
+
+/**
+ * Looks up a path binding registered on this controller for [path] and returns the
+ * resulting [NavigationKey], or `null` if no binding matches.
+ */
+@ExperimentalEnroApi
+public fun EnroController.getNavigationKeyFromPath(path: String): NavigationKey? {
+    val parsedPath = ParsedPath.fromString(path)
+    @Suppress("UNCHECKED_CAST")
+    val binding = paths.getPathBinding(parsedPath) as? NavigationPathBinding<NavigationKey>
+    return binding?.fromPath(parsedPath)
+}

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/path/EnroController.getPathFromNavigationKey.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/path/EnroController.getPathFromNavigationKey.kt
@@ -1,0 +1,15 @@
+package dev.enro.path
+
+import dev.enro.EnroController
+import dev.enro.NavigationKey
+import dev.enro.annotations.ExperimentalEnroApi
+
+/**
+ * Returns a URL-style path string for [key] using the first registered binding whose
+ * keyType matches, or `null` if no binding exists for [key]'s type.
+ */
+@ExperimentalEnroApi
+public fun EnroController.getPathFromNavigationKey(key: NavigationKey): String? {
+    val binding = paths.getPathBindingForKey(key) ?: return null
+    return binding.toPath(key)
+}

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/path/NavigationContext.getPathFromNavigationKey.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/path/NavigationContext.getPathFromNavigationKey.kt
@@ -5,8 +5,8 @@ import dev.enro.annotations.ExperimentalEnroApi
 import dev.enro.context.NavigationContext
 
 @ExperimentalEnroApi
-public fun NavigationContext<*, *>.getNavigationKeyFromPath(
-    path: String,
-): NavigationKey? {
-    return controller.getNavigationKeyFromPath(path)
+public fun NavigationContext<*, *>.getPathFromNavigationKey(
+    key: NavigationKey,
+): String? {
+    return controller.getPathFromNavigationKey(key)
 }

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/path/NavigationHandle.getNavigationKeyFromPath.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/path/NavigationHandle.getNavigationKeyFromPath.kt
@@ -1,0 +1,13 @@
+package dev.enro.path
+
+import dev.enro.EnroController
+import dev.enro.NavigationHandle
+import dev.enro.NavigationKey
+import dev.enro.annotations.ExperimentalEnroApi
+
+@ExperimentalEnroApi
+public fun NavigationHandle<*>.getNavigationKeyFromPath(
+    path: String,
+): NavigationKey? {
+    return EnroController.requireInstance().getNavigationKeyFromPath(path)
+}

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/path/NavigationHandle.getPathFromNavigationKey.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/path/NavigationHandle.getPathFromNavigationKey.kt
@@ -1,0 +1,13 @@
+package dev.enro.path
+
+import dev.enro.EnroController
+import dev.enro.NavigationHandle
+import dev.enro.NavigationKey
+import dev.enro.annotations.ExperimentalEnroApi
+
+@ExperimentalEnroApi
+public fun NavigationHandle<*>.getPathFromNavigationKey(
+    key: NavigationKey,
+): String? {
+    return EnroController.requireInstance().getPathFromNavigationKey(key)
+}

--- a/enro-runtime/src/commonTest/kotlin/dev/enro/PathBindingIntegrationTests.kt
+++ b/enro-runtime/src/commonTest/kotlin/dev/enro/PathBindingIntegrationTests.kt
@@ -1,13 +1,18 @@
 package dev.enro
 
+import dev.enro.annotations.ExperimentalEnroApi
 import dev.enro.controller.createNavigationModule
 import dev.enro.path.NavigationPathBinding
+import dev.enro.path.PathData
 import dev.enro.path.createPathBinding
+import dev.enro.path.fromBinding
 import dev.enro.path.getNavigationKeyFromPath
+import dev.enro.path.getPathFromNavigationKey
 import dev.enro.test.EnroTest
 import dev.enro.test.fixtures.NavigationContextFixtures
 import dev.enro.test.runEnroTest
 import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmInline
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -121,6 +126,103 @@ class PathBindingIntegrationTests {
             message = "Error should call out the ambiguity; was: ${error.message}",
         )
     }
+
+    @Test
+    fun `getPathFromNavigationKey serializes a key back to its registered path`() = runEnroTest {
+        val binding = NavigationPathBinding.createPathBinding<String, ProductDetailPathKey>(
+            pattern = "products/{productId}",
+            propertyOne = ProductDetailPathKey::productId,
+            constructor = { id -> ProductDetailPathKey(id) },
+        )
+        EnroTest.getCurrentNavigationController().addModule(
+            createNavigationModule { path(binding) }
+        )
+        val rootContext = NavigationContextFixtures.createRootContext()
+
+        val path = rootContext.getPathFromNavigationKey(ProductDetailPathKey("p-42"))
+
+        assertEquals(
+            expected = "/products/p-42",
+            actual = path,
+            message = "Key should serialize through the registered binding into its URL form",
+        )
+    }
+
+    @Test
+    fun `getPathFromNavigationKey returns null when no binding is registered for the key`() = runEnroTest {
+        EnroTest.getCurrentNavigationController().addModule(createNavigationModule { })
+        val rootContext = NavigationContextFixtures.createRootContext()
+
+        val path = rootContext.getPathFromNavigationKey(ProductDetailPathKey("any-id"))
+
+        assertNull(
+            actual = path,
+            message = "Without a registered binding, key->path should return null rather than throw",
+        )
+    }
+
+    @OptIn(ExperimentalEnroApi::class)
+    @Test
+    fun `NavigationKey PathBinding round-trips a key through fromBinding helper`() = runEnroTest {
+        val binding = NavigationPathBinding.fromBinding(
+            keyType = ProductDetailPathKey::class,
+            binding = ProductDetailPathKeyBinding,
+        )
+        EnroTest.getCurrentNavigationController().addModule(
+            createNavigationModule { path(binding) }
+        )
+        val rootContext = NavigationContextFixtures.createRootContext()
+
+        val resolved = rootContext.getNavigationKeyFromPath("/binding/products?id=p-7")
+        val serialized = rootContext.getPathFromNavigationKey(ProductDetailPathKey("p-7"))
+
+        assertEquals(
+            expected = ProductDetailPathKey("p-7"),
+            actual = resolved,
+            message = "fromBinding should drive the deserialize side via the user's PathBinding",
+        )
+        assertEquals(
+            expected = "/binding/products?id=p-7",
+            actual = serialized,
+            message = "fromBinding should drive the serialize side via the user's PathBinding",
+        )
+    }
+
+    @Test
+    fun `Value class path parameters round-trip through an explicit NavigationPathBinding`() = runEnroTest {
+        val binding = NavigationPathBinding(
+            keyType = ValueClassPathKey::class,
+            pattern = "/customers/{id}?count={count?}",
+            deserialize = {
+                ValueClassPathKey(
+                    id = CustomerIdValue(require("id")),
+                    count = optional("count")?.toInt()?.let { CountValue(it) },
+                )
+            },
+            serialize = { key ->
+                set("id", key.id.value)
+                key.count?.let { v -> set("count", v.raw.toString()) }
+            },
+        )
+        EnroTest.getCurrentNavigationController().addModule(
+            createNavigationModule { path(binding) }
+        )
+        val rootContext = NavigationContextFixtures.createRootContext()
+
+        val resolved = rootContext.getNavigationKeyFromPath("/customers/cust-1?count=3")
+        val serialized = rootContext.getPathFromNavigationKey(
+            ValueClassPathKey(CustomerIdValue("cust-1"), CountValue(3)),
+        )
+
+        assertEquals(
+            expected = ValueClassPathKey(CustomerIdValue("cust-1"), CountValue(3)),
+            actual = resolved,
+        )
+        assertEquals(
+            expected = "/customers/cust-1?count=3",
+            actual = serialized,
+        )
+    }
 }
 
 @Serializable
@@ -131,3 +233,28 @@ data object SettingsPathKey : NavigationKey
 
 @Serializable
 data object AnotherPathKey : NavigationKey
+
+@OptIn(ExperimentalEnroApi::class)
+private object ProductDetailPathKeyBinding : NavigationKey.PathBinding<ProductDetailPathKey> {
+    override val pattern: String = "/binding/products?id={id?}"
+    override fun deserialize(data: PathData): ProductDetailPathKey {
+        return ProductDetailPathKey(productId = data.optional("id") ?: "missing")
+    }
+    override fun serialize(builder: PathData.Builder, key: ProductDetailPathKey) {
+        builder.set("id", key.productId)
+    }
+}
+
+@JvmInline
+@Serializable
+value class CustomerIdValue(val value: String)
+
+@JvmInline
+@Serializable
+value class CountValue(val raw: Int)
+
+@Serializable
+data class ValueClassPathKey(
+    val id: CustomerIdValue,
+    val count: CountValue? = null,
+) : NavigationKey

--- a/enro-runtime/src/commonTest/kotlin/dev/enro/PathBindingIntegrationTests.kt
+++ b/enro-runtime/src/commonTest/kotlin/dev/enro/PathBindingIntegrationTests.kt
@@ -101,6 +101,37 @@ class PathBindingIntegrationTests {
     }
 
     @Test
+    fun `getNavigationKeyFromPath prefers the most specific matching binding`() = runEnroTest {
+        val genericProduct = NavigationPathBinding.createPathBinding<String, ProductDetailPathKey>(
+            pattern = "products/{productId}",
+            propertyOne = ProductDetailPathKey::productId,
+            constructor = { id -> ProductDetailPathKey(id) },
+        )
+        val specialProduct = NavigationPathBinding.createPathBinding<SettingsPathKey>(
+            pattern = "products/special",
+            constructor = { SettingsPathKey },
+        )
+        EnroTest.getCurrentNavigationController().addModule(
+            createNavigationModule {
+                path(genericProduct)
+                path(specialProduct)
+            }
+        )
+        val rootContext = NavigationContextFixtures.createRootContext()
+
+        assertEquals(
+            expected = SettingsPathKey,
+            actual = rootContext.getNavigationKeyFromPath("products/special"),
+            message = "Literal segment should win over parameter segment for the same path",
+        )
+        assertEquals(
+            expected = ProductDetailPathKey("p-1"),
+            actual = rootContext.getNavigationKeyFromPath("products/p-1"),
+            message = "Generic binding should still match other paths",
+        )
+    }
+
+    @Test
     fun `Two bindings that match the same path throw IllegalArgumentException when resolving`() = runEnroTest {
         val first = NavigationPathBinding.createPathBinding<SettingsPathKey>(
             pattern = "ambiguous",

--- a/tests/application/src/commonMain/kotlin/dev/enro/tests/application/compose/ComposableNavigationPath.kt
+++ b/tests/application/src/commonMain/kotlin/dev/enro/tests/application/compose/ComposableNavigationPath.kt
@@ -3,28 +3,44 @@ package dev.enro.tests.application.compose
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import dev.enro.NavigationKey
+import dev.enro.annotations.ExperimentalEnroApi
 import dev.enro.annotations.NavigationDestination
 import dev.enro.annotations.NavigationPath
 import dev.enro.navigationHandle
+import dev.enro.path.PathData
 import dev.enro.tests.application.compose.common.TitledColumn
 import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmInline
 
+@JvmInline
+@Serializable
+value class PathItemId(val value: String)
+
+@OptIn(ExperimentalEnroApi::class)
 @Serializable
 @NavigationPath("/composable-with-path/{id}?name={name}&title={title?}")
+@NavigationPath.FromBinding(ComposableNavigationPath.Default::class)
 data class ComposableNavigationPath(
-    val id: String,
+    val id: PathItemId,
     val name: String,
     val title: String? = null,
 ) : NavigationKey {
 
-    @NavigationPath("/composable-with-path?title={title?}")
-    constructor(
-        title: String?,
-    ): this(
-        id = "default-id",
-        name = "default-name",
-        title = title
-    )
+    object Default : NavigationKey.PathBinding<ComposableNavigationPath> {
+        override val pattern: String = "/composable-with-path?title={title?}"
+
+        override fun deserialize(data: PathData): ComposableNavigationPath {
+            return ComposableNavigationPath(
+                id = PathItemId("default-id"),
+                name = "default-name",
+                title = data.optional("title"),
+            )
+        }
+
+        override fun serialize(builder: PathData.Builder, key: ComposableNavigationPath) {
+            key.title?.let { builder.set("title", it) }
+        }
+    }
 }
 
 @Composable
@@ -32,7 +48,7 @@ data class ComposableNavigationPath(
 fun ComposableNavigationPathDestination() {
     val navigation = navigationHandle<ComposableNavigationPath>()
     TitledColumn("Composable Navigation Path") {
-        Text("id: ${navigation.key.id}")
+        Text("id: ${navigation.key.id.value}")
         Text("name: ${navigation.key.name}")
         Text("title: ${navigation.key.title}")
     }


### PR DESCRIPTION
## Summary

Fills out four missing pieces of the `@NavigationPath` / path-binding feature so it can carry more realistic deeplink use cases:

- **`@NavigationPath.FromBinding(MyBinding::class)`** — the placeholder `FromBuilder` annotation is repurposed into a real escape hatch. It points at a user-implemented `NavigationKey.PathBinding<T>` (typically a nested `object` on the key), which owns the pattern, `deserialize(PathData)`, and `serialize(PathData.Builder, key)` logic. This replaces the prior "add a secondary constructor with default values" workaround, which forced you to over-design the key class just to satisfy the generator.
- **Value class path parameters** — e.g. `value class CustomerId(val value: String)` is now legal in any `@NavigationPath`-bound constructor. The KSP processor detects value-class properties at compile time, validates that the wrapped type is a supported primitive, and generates an explicit `NavigationPathBinding(keyType, pattern, deserialize, serialize)` form that inlines the wrap/unwrap. The same explicit-form path also lifts the previous 8-parameter ceiling — patterns can now have any arity.
- **Full path↔key API on `EnroController`** — `getNavigationKeyFromPath(path)` now lives on the controller (the previous `NavigationContext` extension was the only entry point and only handled one direction). `getPathFromNavigationKey(key)` is new and rounds out the reverse direction. Matching extensions on `NavigationContext` (now a thin delegate) and `NavigationHandle` make the API available from anywhere.
- **Specificity scoring on ambiguous path matches** — when multiple bindings match the same URL, the most specific one wins instead of throwing. "Specific" is defined as more literal path segments first, then more required query params; ties at the top score still throw (the existing safety net for genuinely ambiguous patterns). So `/products/special` now resolves to the `/products/special` binding rather than the `/products/{id}` one. The scoring logic is encapsulated in `NavigationPathBinding.resolveForPath(bindings, path)` so the score itself isn't part of the public API.

## Why

1. **Value classes are the idiomatic way to model typed IDs in Kotlin.** `data class K(val id: CustomerId)` was an obvious thing to want, but `checkParameterIsSupported<P>` rejected anything that wasn't a literal primitive. Real apps had to either drop the type safety or hand-roll their bindings.
2. **`@NavigationPath.FromBuilder` was a placeholder that never did anything** — the processor's annotation lookup was `getAnnotationsByType(NavigationPath::class)`, so `FromBuilder` annotations were silently ignored. The rename to `FromBinding` reflects the actual responsibility (pointing at a binding class) and finally wires it up.
3. **Reverse direction matters for deeplinks** — generating a URL from a key (for share-sheets, deep-link instrumentation, etc.) was only possible by holding a `NavigationPathBinding<T>` reference directly. Making it a first-class controller API closes that gap.
4. **Forcing every overlap to throw was too strict** — a pattern like `/products/special` alongside `/products/{id}` is a normal routing pattern, not a bug. The "throw on any overlap" rule made it unusable.

Smaller cleanups bundled in:
- `PathData` no longer leaks a `MutableMap` through a public constructor; `Builder` is the only public construction path.
- `NavigationPathBinding.matches(key)` overload for symmetry with the existing `matches(path)`.
- `PathRepository.getPathBindingForKey(key)` / `getPathBindingsForKey(key)` reverse-direction lookup.

## Shape of the new API

```kotlin
@OptIn(ExperimentalEnroApi::class)
@Serializable
@NavigationPath("/composable-with-path/{id}?name={name}&title={title?}")
@NavigationPath.FromBinding(ComposableNavigationPath.Default::class)
data class ComposableNavigationPath(
    val id: PathItemId,            // value class, wrapped/unwrapped automatically
    val name: String,
    val title: String? = null,
) : NavigationKey {

    object Default : NavigationKey.PathBinding<ComposableNavigationPath> {
        override val pattern: String = "/composable-with-path?title={title?}"

        override fun deserialize(data: PathData): ComposableNavigationPath {
            return ComposableNavigationPath(
                id = PathItemId("default-id"),
                name = "default-name",
                title = data.optional("title"),
            )
        }

        override fun serialize(builder: PathData.Builder, key: ComposableNavigationPath) {
            key.title?.let { builder.set("title", it) }
        }
    }
}
```

```kotlin
val controller: EnroController = ...
val key: NavigationKey? = controller.getNavigationKeyFromPath("/customers/c-7?count=3")
val url: String?         = controller.getPathFromNavigationKey(ComposableNavigationPath(...))
```

## What's NOT in scope (deliberately)

- No scheme/host/fragment support; still path + query only.
- No runtime type converters for arbitrary types — value classes cover the common case; everything else goes through `@NavigationPath.FromBinding`.
- Path-parameter name remapping (`{id}` ↔ `customerId`) — left for another pass; convention still requires names to match.

## Test plan

- [ ] `./gradlew :enro-runtime:desktopTest` — all `PathBindingIntegrationTests` + `NavigationPathBindingTests` pass (9/9 in the integration suite, 5 are new: reverse direction, missing-binding null, `fromBinding` round-trip, value-class round-trip, specificity preference).
- [ ] `./gradlew :tests:application:compileKotlinDesktop` — the updated `ComposableNavigationPath` example builds end-to-end and exercises both the value-class generator path and the `@NavigationPath.FromBinding` generator path.
- [ ] Inspect `tests/application/build/generated/ksp/desktop/.../ComposableNavigationPathDestination_GeneratedNavigationBinding.kt` to confirm the two bindings come out side-by-side (one explicit form for the value-class path, one `fromBinding(...)` for the `Default` object).
- [ ] Spot-check generated bindings for unrelated simple-primitive keys (e.g. anything else under `tests/application`) — they should still use `createPathBinding<P1..P8>` as before. The new explicit-form codepath is only entered when value classes are present or arity > 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)