### PR TITLE
Fix Fragment result TODO() crash and strip debug printlns

### DIFF
--- a/enro-runtime/src/androidMain/kotlin/dev/enro/result/registerForNavigationResult.fragment.kt
+++ b/enro-runtime/src/androidMain/kotlin/dev/enro/result/registerForNavigationResult.fragment.kt
@@ -29,7 +29,14 @@ public fun <R : Any> Fragment.registerForNavigationResult(
     return PropertyDelegateProvider<Fragment, ReadOnlyProperty<Fragment, NavigationResultChannel<R>>> { thisRef, property ->
         val resultId = "${thisRef::class.java.name}.${property.name}"
         val lazyResultChannel = lazy {
-            val id = arguments?.getNavigationKeyInstance()?.id ?: TODO()
+            val id = arguments?.getNavigationKeyInstance()?.id
+                ?: error(
+                    "registerForNavigationResult on Fragment ${thisRef::class.qualifiedName} " +
+                        "requires the Fragment to be hosted via an Enro navigation flow — its " +
+                        "arguments bundle is missing a NavigationKey.Instance. Open the Fragment " +
+                        "through a NavigationContainer / NavigationHandle, not via FragmentManager " +
+                        "directly."
+                )
             NavigationResultChannel<R>(
                 id = NavigationResultChannel.Id(
                     ownerId = id,

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/result/flow/NavigationFlow.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/result/flow/NavigationFlow.kt
@@ -75,11 +75,6 @@ public class NavigationFlow<T> internal constructor(
 
         val oldSteps = steps
         steps = flowScope.steps
-        println("\nSTEPS")
-        steps.forEach {
-            println(it)
-        }
-        println("-----")
         val container = container ?: return
 
         val existingInstances = container.backstack

--- a/enro-runtime/src/wasmJsMain/kotlin/dev/enro/ui/WebHistoryPlugin.kt
+++ b/enro-runtime/src/wasmJsMain/kotlin/dev/enro/ui/WebHistoryPlugin.kt
@@ -10,6 +10,7 @@ import dev.enro.context.ContainerContext
 import dev.enro.controller.createNavigationModule
 import dev.enro.emptyBackstack
 import dev.enro.path.getPathFromNavigationKey
+import dev.enro.platform.EnroLog
 import dev.enro.plugin.NavigationPlugin
 import kotlinx.browser.window
 import kotlinx.coroutines.CoroutineScope
@@ -164,14 +165,12 @@ internal class WebHistoryPlugin(
                     }
 
                     isClose -> {
-                        println("History close")
                         // when the target state is a close, we need to pop back to that element in the history
                         val previousIndex = historyIndex
                         historyIndex = closeIndex
                         historyStates[historyIndex] = currentState
                         val goDelta = closeIndex - previousIndex
                         if (closeIndex == 0) {
-                            println("going back delta replace: ${goDelta}")
                             window.history.go(goDelta)
                             window.history.replaceState(
                                 serializedCurrentState,
@@ -179,7 +178,6 @@ internal class WebHistoryPlugin(
                                 computeUrl(),
                             )
                         } else {
-                            println("going back delta push: ${goDelta}")
                             window.history.go(goDelta - 1)
                             delay(1)
                             window.history.pushState(
@@ -303,7 +301,7 @@ internal suspend fun applyNodeFor(
         container.activeChild
     }
     if (childContext == null) {
-        println("Failed to restore")
+        EnroLog.warn("WebHistoryPlugin: failed to restore child container while applying popped state")
         return
     }
     val containers = childContext.children


### PR DESCRIPTION
## Summary

Two small but real production-risk fixes ahead of beta hardening.

- **`registerForNavigationResult` on Fragment no longer throws `NotImplementedError`.** The Fragment variant called `TODO()` whenever the Fragment's arguments bundle didn't contain a `NavigationKey.Instance` — which happens any time someone adds the Fragment through `FragmentManager` directly instead of opening it via an Enro navigation flow. That's a real usage error, not an unimplemented feature, so it now `error()`s with a message pointing at the actual misuse:

  > registerForNavigationResult on Fragment com.example.MyFragment requires the Fragment to be hosted via an Enro navigation flow — its arguments bundle is missing a NavigationKey.Instance. Open the Fragment through a NavigationContainer / NavigationHandle, not via FragmentManager directly.

- **Six stray `println` calls removed.** Three in `WebHistoryPlugin.isClose` (`"History close"`, `"going back delta replace: …"`, `"going back delta push: …"`) and three in `NavigationFlow`'s step-dump (`"\nSTEPS"`, `println(it)`, `"-----"`). Pure leftover debug output from feature work. The genuinely useful `"Failed to restore"` line in `WebHistoryPlugin.applyNodeFor` stays but routes through `EnroLog.warn` so real failures still surface without polluting normal console output.

## Why

Both items would have been embarrassing in a beta:

- The Fragment `TODO()` would crash apps with `kotlin.NotImplementedError: An operation is not implemented.` and no useful diagnostic — looks like the library is broken when it's actually telling the user they hosted the Fragment wrong.
- Stray `println` calls spam the console in every web app that hits a history close, and every flow update on every platform.

These were small enough to bundle as a quick-win PR before tackling Tier-2 beta hardening (SyntheticDestinationScope completeness, `EnroController.isDebug` configuration, deprecation message cleanup, `enro-compat` removal plan).

## Test plan

- [ ] `./gradlew :enro-runtime:compileDebugKotlinAndroid :enro-runtime:compileKotlinDesktop :enro-runtime:compileKotlinWasmJs` — all three targets compile.
- [ ] Spot-check: `grep -rn 'println' enro-runtime/src --include='*.kt' | grep -v EnroLog` returns nothing.
- [ ] Manually: adding a Fragment via `FragmentManager.beginTransaction().add(MyFragmentWithRegisterForResult())` and then accessing the result channel produces an `IllegalStateException` with the diagnostic message rather than `NotImplementedError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)