### PR TITLE
Beta hardening: expose isDebug + write real Render deprecation

### DIFF
--- a/enro-processor/src/main/java/dev/enro/processor/generator/NavigationComponentGenerator.kt
+++ b/enro-processor/src/main/java/dev/enro/processor/generator/NavigationComponentGenerator.kt
@@ -77,6 +77,11 @@ object NavigationComponentGenerator {
             .returns(ClassNames.Kotlin.navigationController)
             .addPlatformParameter()
             .addParameter(
+                ParameterSpec.builder("isDebug", Boolean::class)
+                    .defaultValue("false")
+                    .build()
+            )
+            .addParameter(
                 ParameterSpec.builder(
                     "block",
                     LambdaTypeName.get(
@@ -103,10 +108,11 @@ object NavigationComponentGenerator {
             .addCode(
                 """
                     val controller = internalCreateEnroController(
+                        isDebug = isDebug,
                         builder = {
-                            ${generatedComponent.name}().apply { 
+                            ${generatedComponent.name}().apply {
                                 module(module)
-                                invoke() 
+                                invoke()
                             }
                             block()
                         }
@@ -148,6 +154,7 @@ object NavigationComponentGenerator {
                         return androidx.compose.runtime.remember {
                             installNavigationController(
                                 $platformParameterName = Unit,
+                                isDebug = isDebug,
                                 block = block,
                             )
                         }

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/EnroController.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/EnroController.kt
@@ -17,8 +17,9 @@ import kotlinx.serialization.json.Json
 
 @Stable
 public class EnroController {
-    // TODO NEED TO CONFIGURE THIS
-    internal val isDebug = false
+    // Set during construction by internalCreateEnroController, plumbed through
+    // from the isDebug parameter on the generated installNavigationController.
+    internal var isDebug: Boolean = false
     internal var platformReference: Any? = null
     internal val plugins = PluginRepository()
     internal val bindings = BindingRepository(plugins)

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/controller/internalCreateEnroController.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/controller/internalCreateEnroController.kt
@@ -5,10 +5,12 @@ import dev.enro.platform.platformNavigationModule
 
 // Marked as internal, but is used in generated code with a @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
 internal fun internalCreateEnroController(
+    isDebug: Boolean = false,
     builder: NavigationModule.BuilderScope.() -> Unit = {},
 ) : EnroController {
     val module = createNavigationModule(builder)
     return EnroController().apply {
+        this.isDebug = isDebug
         addModule(defaultNavigationModule)
         addModule(platformNavigationModule)
         addModule(module)

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/ui/NavigationContainerState.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/ui/NavigationContainerState.kt
@@ -77,7 +77,14 @@ public class NavigationContainerState(
         container.setBackstackDirect(restoredBackstack.asBackstack())
     }
 
-    @Deprecated("TODO BETTER DEPRECATION MESSAGE")
+    @Deprecated(
+        message = "Use NavigationDisplay(state) instead. This method only exists for migration ergonomics and will be removed before 3.0 stable.",
+        replaceWith = ReplaceWith(
+            expression = "NavigationDisplay(this)",
+            imports = ["dev.enro.ui.NavigationDisplay"],
+        ),
+        level = DeprecationLevel.WARNING,
+    )
     @Composable
     public fun Render() {
         NavigationDisplay(this)


### PR DESCRIPTION
## Summary

Two small beta-readiness items from the Tier-2 hardening list.

- **`isDebug` is now a parameter on `installNavigationController`** (and `rememberNavigationController`). The hardcoded `internal val isDebug = false` was a feature flag with no way to turn it on — the metadata-serializer validation it gates never ran in any real app. The processor now generates `installNavigationController` with an `isDebug: Boolean = false` parameter that's plumbed through `internalCreateEnroController` to set the flag on the controller before any module is added.

  ```kotlin
  MyComponent.installNavigationController(this, isDebug = BuildConfig.DEBUG)
  ```

  `isDebug` stays `internal var` on `EnroController` itself — it's not toggleable post-install — so the public API surface is just the install-time parameter.

- **`NavigationContainerState.Render` deprecation now has a real message.** The placeholder `@Deprecated("TODO BETTER DEPRECATION MESSAGE")` is replaced with proper text + `ReplaceWith(NavigationDisplay(this))` — which is what `Render` was already delegating to internally.

## Why

Both items would be embarrassing in a beta:

- `isDebug` was a feature flag with no way to turn it on. The serializer validation it controls is meant to surface missing serializers loudly in debug builds, but as shipped it was permanently off.
- The placeholder deprecation message would be visible in users' IDEs as a literal TODO string.

## What's NOT in this PR

- **`SyntheticDestinationScope` completeness** — the bigger Tier-2 item that needs to collect operations during the block and integrate with the result-channel system. Wants design discussion and a focused PR.
- **`enro-compat` removal plan** — product decision, not code.
- **Test-fixture `TODO()` calls** in `NavigationPathBindingTests` — turned out to be a false alarm; they're intentional placeholders for deserialize/serialize lambdas that aren't exercised in tests that only check `matches()`.

## Test plan

- [ ] `./gradlew :enro-runtime:desktopTest` — green, no regressions.
- [ ] `./gradlew :tests:application:compileKotlinDesktop` — test app compiles against the new generated install signature.
- [ ] Inspect `tests/application/build/generated/ksp/desktop/.../TestApplicationComponentNavigation.kt` — confirm `installNavigationController` and `rememberNavigationController` both take and forward `isDebug`.
- [ ] Spot-check: IDE shows the real deprecation message on `NavigationContainerState.Render()` usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)