### PR TITLE
SyntheticDestinationScope: throw-based outcomes

### DIFF
--- a/enro-compat/src/androidMain/kotlin/dev/enro/core/result/SyntheticDestinationScope.sendResult.kt
+++ b/enro-compat/src/androidMain/kotlin/dev/enro/core/result/SyntheticDestinationScope.sendResult.kt
@@ -1,32 +1,34 @@
 package dev.enro.core.result
 
 import dev.enro.NavigationKey
-import dev.enro.NavigationOperation
 import dev.enro.core.NavigationDirection
-import dev.enro.core.getNavigationHandle
 import dev.enro.ui.destinations.SyntheticDestinationScope
+import dev.enro.ui.destinations.complete
+import dev.enro.ui.destinations.completeFrom
 
-public fun <T: Any> SyntheticDestinationScope<out NavigationKey.WithResult<T>>.sendResult(
-    result: T
-) {
-    AdvancedResultExtensions.setResultForInstruction(
-        navigationController = context.controller,
-        instruction = instance,
-        result = result
-    )
-}
+@Deprecated(
+    message = "Use SyntheticDestinationScope.complete(result) instead. The direction concept from Enro 2 is no longer relevant; the new method registers the same Completed result against the synthetic's result channel.",
+    replaceWith = ReplaceWith(
+        expression = "complete(result)",
+        imports = ["dev.enro.ui.destinations.complete"],
+    ),
+)
+public fun <T : Any> SyntheticDestinationScope<out NavigationKey.WithResult<T>>.sendResult(
+    result: T,
+): Nothing = complete(result)
 
-public fun <T: Any> SyntheticDestinationScope<out NavigationKey.WithResult<T>>.forwardResult(
+@Deprecated(
+    message = "Use SyntheticDestinationScope.completeFrom(navigationKey) instead. The direction parameter is no longer used in Enro 3 — push/present semantics are now expressed elsewhere.",
+    replaceWith = ReplaceWith(
+        expression = "completeFrom(navigationKey)",
+        imports = ["dev.enro.ui.destinations.completeFrom"],
+    ),
+)
+@Suppress("UNUSED_PARAMETER")
+public fun <T : Any> SyntheticDestinationScope<out NavigationKey.WithResult<T>>.forwardResult(
     navigationKey: NavigationKey.WithResult<T>,
-    direction: NavigationDirection = when(navigationKey) {
+    direction: NavigationDirection = when (navigationKey) {
         is dev.enro.core.NavigationKey.SupportsPresent -> NavigationDirection.Present
         else -> NavigationDirection.Push
-    }
-) {
-    val instruction = AdvancedResultExtensions.getInstructionToForwardResult(
-        originalInstruction = instance,
-        direction = direction,
-        navigationKey = navigationKey
-    )
-    context.getNavigationHandle().execute(NavigationOperation.Open(instruction))
-}
+    },
+): Nothing = completeFrom(navigationKey)

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/interceptor/NavigationInterceptor.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/interceptor/NavigationInterceptor.kt
@@ -5,7 +5,6 @@ import dev.enro.NavigationContext
 import dev.enro.NavigationKey
 import dev.enro.NavigationOperation
 import dev.enro.context.ContainerContext
-import dev.enro.platform.EnroLog
 import dev.enro.result.NavigationResultChannel
 
 /**
@@ -127,22 +126,17 @@ public abstract class NavigationInterceptor {
                 when (it) {
                     is NavigationOperation.Close<NavigationKey> -> {
                         closedIds.add(it.instance.id)
-                        if (!backstackById.containsKey(it.instance.id)) {
-                            EnroLog.warn(
-                                "Attempted to close a NavigationKey.Instance that was not on the backstack: ${it.instance}."
-                            )
-                            return@mapNotNull null
-                        }
+                        // We don't filter Close operations whose instance isn't on
+                        // the backstack — synthetic destinations legitimately
+                        // dispatch a Close for an instance that never landed in
+                        // any backstack so their result channel still fires.
                     }
                     is NavigationOperation.Complete<NavigationKey> -> {
                         closedIds.add(it.instance.id)
                         completedResultIds.add(it.instance.metadata.get(NavigationResultChannel.ResultIdKey))
-                        if (!backstackById.containsKey(it.instance.id)) {
-                            EnroLog.warn(
-                                "Attempted to complete a NavigationKey.Instance that was not on the backstack: ${it.instance}."
-                            )
-                            return@mapNotNull null
-                        }
+                        // Same reasoning as Close above — synthetics complete
+                        // off-backstack instances; the result-channel side
+                        // effect is the important bit and must still fire.
                     }
                     is NavigationOperation.Open<NavigationKey> -> {
                         openedIds.add(it.instance.id)

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticDestination.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticDestination.kt
@@ -10,10 +10,10 @@ import dev.enro.ui.NavigationDestination
 import dev.enro.ui.NavigationDestinationProvider
 import dev.enro.ui.navigationDestination
 
-public class SyntheticDestination<K : NavigationKey>(
+internal class SyntheticDestination<K : NavigationKey>(
     internal val block: SyntheticDestinationScope<K>.() -> Unit,
 ) {
-    public companion object {
+    internal companion object {
         internal const val SyntheticDestinationKey = "dev.enro.ui.destinations.SyntheticDestinationKey"
 
         internal val interceptor = object : NavigationInterceptor() {
@@ -33,7 +33,7 @@ public class SyntheticDestination<K : NavigationKey>(
             }
         }
 
-        public fun executeSynthetic(
+        internal fun executeSynthetic(
             fromContext: NavigationContext,
             containerContext: ContainerContext,
             instance: NavigationKey.Instance<NavigationKey>,
@@ -47,20 +47,24 @@ public class SyntheticDestination<K : NavigationKey>(
                 context = fromContext,
                 instance = instance,
             )
-            val outcome = try {
+            val thrown = try {
                 synthetic.block(scope)
                 null
             } catch (outcome: SyntheticDestinationOutcome) {
                 outcome
             }
-            if (outcome == null) return
 
-            val operation = when (outcome) {
+            // If the block fell through without calling an outcome method, settle
+            // the scope on a silent close. This locks the scope so any subsequent
+            // call from a stray coroutine throws the "already finished" error.
+            val effectiveOutcome = thrown ?: scope.finalizeAsSilentCloseIfNoOutcome()
+
+            val operation = when (effectiveOutcome) {
                 is SyntheticDestinationOutcome.Open ->
-                    NavigationOperation.Open(outcome.target)
+                    NavigationOperation.Open(effectiveOutcome.target)
                 is SyntheticDestinationOutcome.Close ->
-                    NavigationOperation.Close(instance)
-                is SyntheticDestinationOutcome.Complete -> when (val result = outcome.result) {
+                    NavigationOperation.Close(instance, silent = effectiveOutcome.silent)
+                is SyntheticDestinationOutcome.Complete -> when (val result = effectiveOutcome.result) {
                     null -> NavigationOperation.Complete(instance)
                     else -> {
                         @Suppress("UNCHECKED_CAST")
@@ -71,7 +75,7 @@ public class SyntheticDestination<K : NavigationKey>(
                     }
                 }
                 is SyntheticDestinationOutcome.CompleteFrom ->
-                    NavigationOperation.CompleteFrom(instance, outcome.target)
+                    NavigationOperation.CompleteFrom(instance, effectiveOutcome.target)
             }
             containerContext.container.execute(fromContext, operation)
         }
@@ -80,8 +84,8 @@ public class SyntheticDestination<K : NavigationKey>(
 
 public fun <K : NavigationKey> syntheticDestination(
     metadata: NavigationDestination.MetadataBuilder<K>.() -> Unit = {},
-    block: SyntheticDestinationScope<K>.() -> Unit
-) : NavigationDestinationProvider<K> {
+    block: SyntheticDestinationScope<K>.() -> Unit,
+): NavigationDestinationProvider<K> {
     return navigationDestination(
         metadata = {
             metadata.invoke(this)
@@ -93,7 +97,7 @@ public fun <K : NavigationKey> syntheticDestination(
 }
 
 public fun isSyntheticDestination(
-    instance: NavigationKey.Instance<*>
+    instance: NavigationKey.Instance<*>,
 ): Boolean {
     return EnroController.instance?.bindings?.bindingFor(instance)
         ?.provider
@@ -101,4 +105,3 @@ public fun isSyntheticDestination(
         ?.contains(SyntheticDestination.SyntheticDestinationKey)
         ?: false
 }
-

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticDestination.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticDestination.kt
@@ -23,10 +23,11 @@ public class SyntheticDestination<K : NavigationKey>(
                 operation: NavigationOperation.Open<NavigationKey>,
             ): NavigationOperation? {
                 if (!isSyntheticDestination(operation.instance)) return operation
-                return NavigationOperation.SideEffect{
+                return NavigationOperation.SideEffect {
                     executeSynthetic(
                         fromContext = fromContext,
-                        instance = operation.instance
+                        containerContext = containerContext,
+                        instance = operation.instance,
                     )
                 }
             }
@@ -34,6 +35,7 @@ public class SyntheticDestination<K : NavigationKey>(
 
         public fun executeSynthetic(
             fromContext: NavigationContext,
+            containerContext: ContainerContext,
             instance: NavigationKey.Instance<NavigationKey>,
         ) {
             val controller = fromContext.controller
@@ -41,14 +43,38 @@ public class SyntheticDestination<K : NavigationKey>(
             val syntheticDestination = bindings.provider.peekMetadata(instance)[SyntheticDestinationKey]
             @Suppress("UNCHECKED_CAST")
             val synthetic = requireNotNull(syntheticDestination) as SyntheticDestination<NavigationKey>
-            synthetic.block(
-                SyntheticDestinationScope(
-                    context = fromContext,
-                    instance = instance,
-                )
+            val scope = SyntheticDestinationScope(
+                context = fromContext,
+                instance = instance,
             )
-        }
+            val outcome = try {
+                synthetic.block(scope)
+                null
+            } catch (outcome: SyntheticDestinationOutcome) {
+                outcome
+            }
+            if (outcome == null) return
 
+            val operation = when (outcome) {
+                is SyntheticDestinationOutcome.Open ->
+                    NavigationOperation.Open(outcome.target)
+                is SyntheticDestinationOutcome.Close ->
+                    NavigationOperation.Close(instance)
+                is SyntheticDestinationOutcome.Complete -> when (val result = outcome.result) {
+                    null -> NavigationOperation.Complete(instance)
+                    else -> {
+                        @Suppress("UNCHECKED_CAST")
+                        NavigationOperation.Complete(
+                            instance = instance as NavigationKey.Instance<NavigationKey.WithResult<Any>>,
+                            result = result,
+                        )
+                    }
+                }
+                is SyntheticDestinationOutcome.CompleteFrom ->
+                    NavigationOperation.CompleteFrom(instance, outcome.target)
+            }
+            containerContext.container.execute(fromContext, operation)
+        }
     }
 }
 

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticDestinationOutcome.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticDestinationOutcome.kt
@@ -1,0 +1,31 @@
+package dev.enro.ui.destinations
+
+import dev.enro.NavigationKey
+
+/**
+ * Sentinel exception thrown by the outcome methods on [SyntheticDestinationScope]
+ * (e.g. `open`, `close`, `complete`, `completeFrom`) to signal the synthetic's
+ * decision back up to the synthetic dispatcher. The dispatcher catches the
+ * subclass and converts it to the corresponding [dev.enro.NavigationOperation].
+ *
+ * Throwing for control flow mirrors the pattern used by [InterceptorBuilderResult][dev.enro.interceptor.builder.InterceptorBuilderResult]
+ * — it lets the scope methods return [Nothing] so the synthetic block can
+ * short-circuit naturally from inside conditionals.
+ */
+@PublishedApi
+internal sealed class SyntheticDestinationOutcome : RuntimeException() {
+
+    internal class Open(
+        val target: NavigationKey.Instance<NavigationKey>,
+    ) : SyntheticDestinationOutcome()
+
+    internal class Close : SyntheticDestinationOutcome()
+
+    internal class Complete(
+        val result: Any?,
+    ) : SyntheticDestinationOutcome()
+
+    internal class CompleteFrom(
+        val target: NavigationKey.Instance<NavigationKey>,
+    ) : SyntheticDestinationOutcome()
+}

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticDestinationOutcome.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticDestinationOutcome.kt
@@ -4,22 +4,25 @@ import dev.enro.NavigationKey
 
 /**
  * Sentinel exception thrown by the outcome methods on [SyntheticDestinationScope]
- * (e.g. `open`, `close`, `complete`, `completeFrom`) to signal the synthetic's
- * decision back up to the synthetic dispatcher. The dispatcher catches the
- * subclass and converts it to the corresponding [dev.enro.NavigationOperation].
+ * (e.g. `open`, `close`, `closeSilently`, `complete`, `completeFrom`) to signal
+ * the synthetic's decision back up to the synthetic dispatcher. The dispatcher
+ * catches the subclass and converts it to the corresponding
+ * [dev.enro.NavigationOperation].
  *
  * Throwing for control flow mirrors the pattern used by [InterceptorBuilderResult][dev.enro.interceptor.builder.InterceptorBuilderResult]
  * — it lets the scope methods return [Nothing] so the synthetic block can
  * short-circuit naturally from inside conditionals.
  */
-@PublishedApi
 internal sealed class SyntheticDestinationOutcome : RuntimeException() {
 
     internal class Open(
         val target: NavigationKey.Instance<NavigationKey>,
     ) : SyntheticDestinationOutcome()
 
-    internal class Close : SyntheticDestinationOutcome()
+    /** Regular close fires the result-channel callback; silent close does not. */
+    internal class Close(
+        val silent: Boolean,
+    ) : SyntheticDestinationOutcome()
 
     internal class Complete(
         val result: Any?,

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticDestinationScope.complete.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticDestinationScope.complete.kt
@@ -11,7 +11,7 @@ import kotlin.jvm.JvmName
  */
 public fun <R : Any> SyntheticDestinationScope<out NavigationKey.WithResult<R>>.complete(
     result: R,
-): Nothing = throw SyntheticDestinationOutcome.Complete(result = result)
+): Nothing = setOutcome(SyntheticDestinationOutcome.Complete(result = result))
 
 /**
  * End the synthetic's outcome decision by opening [key] and routing its
@@ -20,11 +20,11 @@ public fun <R : Any> SyntheticDestinationScope<out NavigationKey.WithResult<R>>.
  */
 public fun <R : Any> SyntheticDestinationScope<out NavigationKey.WithResult<R>>.completeFrom(
     key: NavigationKey.WithResult<R>,
-): Nothing = throw SyntheticDestinationOutcome.CompleteFrom(key.asInstance())
+): Nothing = setOutcome(SyntheticDestinationOutcome.CompleteFrom(key.asInstance()))
 
 public fun <R : Any> SyntheticDestinationScope<out NavigationKey.WithResult<R>>.completeFrom(
     key: NavigationKey.WithMetadata<NavigationKey.WithResult<R>>,
-): Nothing = throw SyntheticDestinationOutcome.CompleteFrom(key.asInstance())
+): Nothing = setOutcome(SyntheticDestinationOutcome.CompleteFrom(key.asInstance()))
 
 @JvmName("completeWithoutResult")
 @Deprecated(

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticDestinationScope.complete.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticDestinationScope.complete.kt
@@ -1,0 +1,47 @@
+package dev.enro.ui.destinations
+
+import dev.enro.NavigationKey
+import dev.enro.asInstance
+import kotlin.jvm.JvmName
+
+/**
+ * End the synthetic's outcome decision by registering a `Completed` result
+ * with the given [result] against whoever opened the synthetic. Only
+ * available when the synthetic's key is a [NavigationKey.WithResult].
+ */
+public fun <R : Any> SyntheticDestinationScope<out NavigationKey.WithResult<R>>.complete(
+    result: R,
+): Nothing = throw SyntheticDestinationOutcome.Complete(result = result)
+
+/**
+ * End the synthetic's outcome decision by opening [key] and routing its
+ * eventual completion back to whoever opened the synthetic. The result
+ * type of [key] must match the synthetic's contract.
+ */
+public fun <R : Any> SyntheticDestinationScope<out NavigationKey.WithResult<R>>.completeFrom(
+    key: NavigationKey.WithResult<R>,
+): Nothing = throw SyntheticDestinationOutcome.CompleteFrom(key.asInstance())
+
+public fun <R : Any> SyntheticDestinationScope<out NavigationKey.WithResult<R>>.completeFrom(
+    key: NavigationKey.WithMetadata<NavigationKey.WithResult<R>>,
+): Nothing = throw SyntheticDestinationOutcome.CompleteFrom(key.asInstance())
+
+@JvmName("completeWithoutResult")
+@Deprecated(
+    message = "A synthetic for a NavigationKey.WithResult cannot complete without a result. Use complete(result) instead.",
+    level = DeprecationLevel.ERROR,
+)
+public fun <R : Any> SyntheticDestinationScope<out NavigationKey.WithResult<R>>.complete(): Nothing {
+    error("${instance.key} is a NavigationKey.WithResult and cannot complete without a result")
+}
+
+@JvmName("completeFromNonResultDeprecated")
+@Deprecated(
+    message = "A synthetic for a NavigationKey.WithResult cannot completeFrom a NavigationKey that does not also implement NavigationKey.WithResult of the same result type.",
+    level = DeprecationLevel.ERROR,
+)
+public fun <R : Any> SyntheticDestinationScope<out NavigationKey.WithResult<R>>.completeFrom(
+    key: NavigationKey,
+): Nothing {
+    error("${instance.key} is a NavigationKey.WithResult and cannot completeFrom a key that is not also a NavigationKey.WithResult of the same result type")
+}

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticDestinationScope.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticDestinationScope.kt
@@ -2,15 +2,36 @@ package dev.enro.ui.destinations
 
 import dev.enro.NavigationContext
 import dev.enro.NavigationKey
+import dev.enro.asInstance
 import dev.enro.context.AnyNavigationContext
 import dev.enro.context.ContainerContext
 import dev.enro.context.DestinationContext
 import dev.enro.context.RootContext
 
-// TODO: Need to add functionality to do a replace/close/complete/completeFrom from the context of
-//  a synthetic destination scope (to allow for "forwardResult" and "setResult") type functionality
-//  that previously existed in Enro 2.x
-public class SyntheticDestinationScope<K : NavigationKey>(
+/**
+ * The receiver scope of a `syntheticDestination { ... }` block. A synthetic
+ * destination is a [NavigationKey] that, when opened, runs the block instead
+ * of rendering a UI; the synthetic instance never reaches a backstack.
+ *
+ * The block can return without calling any outcome method — in that case the
+ * synthetic acts purely as a side-effect bridge (e.g. launching an `Intent`
+ * to Chrome Custom Tabs) and Enro takes no further navigation action.
+ *
+ * Alternatively, the block can short-circuit by calling one of the outcome
+ * methods:
+ *
+ * - [open] — open another [NavigationKey] instead of the synthetic.
+ * - [close] — register a `Closed` result for whoever called the synthetic.
+ * - [complete] — register a `Completed` result. For result-bearing
+ *   synthetics, see the `complete(result: T)` extension.
+ * - [completeFrom] — open another key and have *its* completion fulfil the
+ *   synthetic's contract. Useful for "decider" synthetics that pick one of
+ *   several destinations at runtime.
+ *
+ * Each outcome method throws a sentinel and returns [Nothing], so calls
+ * inside conditionals flow naturally without needing explicit `return`.
+ */
+public class SyntheticDestinationScope<K : NavigationKey> @PublishedApi internal constructor(
     // context is the NavigationContext that is executing this SyntheticDestination,
     // which could be a RootContext, ContainerContext or DestinationContext depending on how
     // the synthetic destination was opened
@@ -25,7 +46,7 @@ public class SyntheticDestinationScope<K : NavigationKey>(
     // and if the context is a RootContext, destinationContext will be the active child of the RootContext's
     // active ContainerContext
     public val destinationContext: DestinationContext<NavigationKey>?
-        get() = when(context) {
+        get() = when (context) {
             is DestinationContext<*> -> context
             is ContainerContext -> context.activeChild
             is RootContext -> context.activeChild?.activeChild
@@ -37,4 +58,46 @@ public class SyntheticDestinationScope<K : NavigationKey>(
 
     @Deprecated("Use instance")
     public val instruction: NavigationKey.Instance<K> = instance
+
+    /**
+     * End the synthetic's outcome decision by opening another [NavigationKey]
+     * in place of this synthetic. The synthetic instance itself never lands
+     * in any backstack.
+     */
+    public fun open(key: NavigationKey): Nothing =
+        throw SyntheticDestinationOutcome.Open(key.asInstance())
+
+    public fun open(key: NavigationKey.WithMetadata<*>): Nothing =
+        throw SyntheticDestinationOutcome.Open(key.asInstance())
+
+    /**
+     * End the synthetic's outcome decision by registering a `Closed` result
+     * against whichever [dev.enro.result.NavigationResultChannel] originally
+     * opened this synthetic.
+     */
+    public fun close(): Nothing = throw SyntheticDestinationOutcome.Close()
+
+    /**
+     * End the synthetic's outcome decision by registering a `Completed`
+     * result with no payload.
+     *
+     * For synthetics whose key is a [NavigationKey.WithResult], this no-arg
+     * overload is shadowed by a deprecated-error extension — you must call
+     * the typed `complete(result: T)` extension instead.
+     */
+    public fun complete(): Nothing = throw SyntheticDestinationOutcome.Complete(result = null)
+
+    /**
+     * End the synthetic's outcome decision by opening [key] and routing its
+     * eventual completion back to whoever opened the synthetic. The
+     * synthetic itself doesn't produce the result; the forwarded key does.
+     *
+     * For synthetics whose key is a [NavigationKey.WithResult], the
+     * forwarded key must also be a [NavigationKey.WithResult] of the same
+     * result type — that variant is provided as an extension; this non-result
+     * overload is blocked on result-bearing scopes by a deprecated-error
+     * extension.
+     */
+    public fun completeFrom(key: NavigationKey): Nothing =
+        throw SyntheticDestinationOutcome.CompleteFrom(key.asInstance())
 }

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticDestinationScope.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticDestinationScope.kt
@@ -15,21 +15,29 @@ import dev.enro.context.RootContext
  *
  * The block can return without calling any outcome method — in that case the
  * synthetic acts purely as a side-effect bridge (e.g. launching an `Intent`
- * to Chrome Custom Tabs) and Enro takes no further navigation action.
+ * to Chrome Custom Tabs) and the synthetic is considered to have closed
+ * silently. No result-channel callback fires for the original caller.
  *
  * Alternatively, the block can short-circuit by calling one of the outcome
  * methods:
  *
- * - [open] — open another [NavigationKey] instead of the synthetic.
+ * - [open] — open another [NavigationKey] in place of the synthetic.
  * - [close] — register a `Closed` result for whoever called the synthetic.
+ * - [closeSilently] — close without firing the result-channel callback.
  * - [complete] — register a `Completed` result. For result-bearing
- *   synthetics, see the `complete(result: T)` extension.
+ *   synthetics see the `complete(result: T)` extension.
  * - [completeFrom] — open another key and have *its* completion fulfil the
  *   synthetic's contract. Useful for "decider" synthetics that pick one of
  *   several destinations at runtime.
  *
  * Each outcome method throws a sentinel and returns [Nothing], so calls
  * inside conditionals flow naturally without needing explicit `return`.
+ *
+ * The scope tracks the outcome it settles on. Once an outcome is set —
+ * whether by an explicit method call inside the block, or by the dispatcher
+ * defaulting to a silent close after the block returns — any subsequent
+ * call (typically from an async coroutine that outlived the block) throws
+ * a clear error instead of silently double-handling.
  */
 public class SyntheticDestinationScope<K : NavigationKey> @PublishedApi internal constructor(
     // context is the NavigationContext that is executing this SyntheticDestination,
@@ -60,22 +68,77 @@ public class SyntheticDestinationScope<K : NavigationKey> @PublishedApi internal
     public val instruction: NavigationKey.Instance<K> = instance
 
     /**
+     * The outcome the synthetic settled on. Null while the block is running and
+     * before any method is called; set the first time one of the scope's
+     * outcome methods runs (or by the dispatcher after the block falls through).
+     * Read by the dispatcher; written via [setOutcome].
+     */
+    internal var outcome: SyntheticDestinationOutcome? = null
+        private set
+
+    /**
+     * Records [newOutcome] and throws it. If an outcome is already set,
+     * throws an [IllegalStateException] instead — this catches the case
+     * where an async coroutine outlived the block and tried to complete /
+     * close the synthetic after the dispatcher already moved on.
+     */
+    internal fun setOutcome(newOutcome: SyntheticDestinationOutcome): Nothing {
+        val current = outcome
+        if (current != null) {
+            error(
+                "SyntheticDestination for ${instance.key} has already finished with " +
+                    "${current::class.simpleName}. A second outcome cannot be set — this " +
+                    "usually means an async coroutine outlived the synthetic block and " +
+                    "tried to complete/close it after the dispatcher had already moved on. " +
+                    "Do any async work before opening the synthetic, or forward to a " +
+                    "destination that owns the work itself."
+            )
+        }
+        outcome = newOutcome
+        throw newOutcome
+    }
+
+    /**
+     * Used by the dispatcher when the block falls through without calling an
+     * outcome method. Records a silent close so that any later coroutine
+     * call sees [outcome] is non-null and throws the "already finished"
+     * error from [setOutcome].
+     */
+    internal fun finalizeAsSilentCloseIfNoOutcome(): SyntheticDestinationOutcome {
+        val existing = outcome
+        if (existing != null) return existing
+        val silent = SyntheticDestinationOutcome.Close(silent = true)
+        outcome = silent
+        return silent
+    }
+
+    /**
      * End the synthetic's outcome decision by opening another [NavigationKey]
      * in place of this synthetic. The synthetic instance itself never lands
      * in any backstack.
      */
     public fun open(key: NavigationKey): Nothing =
-        throw SyntheticDestinationOutcome.Open(key.asInstance())
+        setOutcome(SyntheticDestinationOutcome.Open(key.asInstance()))
 
     public fun open(key: NavigationKey.WithMetadata<*>): Nothing =
-        throw SyntheticDestinationOutcome.Open(key.asInstance())
+        setOutcome(SyntheticDestinationOutcome.Open(key.asInstance()))
 
     /**
      * End the synthetic's outcome decision by registering a `Closed` result
      * against whichever [dev.enro.result.NavigationResultChannel] originally
      * opened this synthetic.
      */
-    public fun close(): Nothing = throw SyntheticDestinationOutcome.Close()
+    public fun close(): Nothing =
+        setOutcome(SyntheticDestinationOutcome.Close(silent = false))
+
+    /**
+     * Close the synthetic without firing the result-channel callback. The
+     * caller's `onClosed` won't run. Use this when the synthetic acts as a
+     * pure side-effect bridge and the original caller doesn't need to know
+     * the synthetic finished.
+     */
+    public fun closeSilently(): Nothing =
+        setOutcome(SyntheticDestinationOutcome.Close(silent = true))
 
     /**
      * End the synthetic's outcome decision by registering a `Completed`
@@ -85,7 +148,8 @@ public class SyntheticDestinationScope<K : NavigationKey> @PublishedApi internal
      * overload is shadowed by a deprecated-error extension — you must call
      * the typed `complete(result: T)` extension instead.
      */
-    public fun complete(): Nothing = throw SyntheticDestinationOutcome.Complete(result = null)
+    public fun complete(): Nothing =
+        setOutcome(SyntheticDestinationOutcome.Complete(result = null))
 
     /**
      * End the synthetic's outcome decision by opening [key] and routing its
@@ -99,5 +163,5 @@ public class SyntheticDestinationScope<K : NavigationKey> @PublishedApi internal
      * extension.
      */
     public fun completeFrom(key: NavigationKey): Nothing =
-        throw SyntheticDestinationOutcome.CompleteFrom(key.asInstance())
+        setOutcome(SyntheticDestinationOutcome.CompleteFrom(key.asInstance()))
 }

--- a/enro-runtime/src/commonTest/kotlin/dev/enro/SyntheticDestinationTests.kt
+++ b/enro-runtime/src/commonTest/kotlin/dev/enro/SyntheticDestinationTests.kt
@@ -238,6 +238,99 @@ class SyntheticDestinationTests {
     }
 
     @Test
+    fun `Synthetic closeSilently does not register a result for the synthetic's channel`() = runEnroTest {
+        EnroTest.getCurrentNavigationController().addModule(
+            createNavigationModule {
+                destination<SyntheticTestKey>(
+                    syntheticDestination<SyntheticTestKey> { closeSilently() }
+                )
+            }
+        )
+        val resultId = NavigationResultChannel.Id(ownerId = "owner", resultId = "ch")
+        val syntheticInstance = SyntheticTestKey.asInstance().apply {
+            metadata.set(NavigationResultChannel.ResultIdKey, resultId)
+        }
+
+        openSynthetic(syntheticInstance)
+
+        assertNull(
+            actual = NavigationResultChannel.pendingResults.value[resultId],
+            message = "closeSilently() must not publish a result; the original caller's onClosed should not fire",
+        )
+    }
+
+    @Test
+    fun `Synthetic close does not strip the parent destination from the backstack`() = runEnroTest {
+        // Belt-and-braces test: the synthetic's Close operation targets the
+        // synthetic's instance (which is never in any backstack), so the
+        // parent destination — the one that opened the synthetic — must
+        // remain on the backstack untouched.
+        EnroTest.getCurrentNavigationController().addModule(
+            createNavigationModule {
+                destination<SyntheticTestKey>(
+                    syntheticDestination<SyntheticTestKey> { close() }
+                )
+                destination<NavigationKeyFixtures.SimpleKey>(
+                    navigationDestination<NavigationKeyFixtures.SimpleKey> { Text("parent") }
+                )
+            }
+        )
+
+        val rootContext = NavigationContextFixtures.createRootContext()
+        val containerContext = NavigationContextFixtures.createContainerContext(rootContext)
+        val container = containerContext.container
+        container.setFilter(acceptAll())
+        container.addInterceptor(SyntheticDestination.interceptor)
+
+        val parentKey = NavigationKeyFixtures.SimpleKey()
+        val parentInstance = parentKey.asInstance()
+        container.setBackstackDirect(backstackOf(parentInstance))
+
+        val parentDestination = NavigationDestinationFixtures.create(parentKey)
+        val parentContext = NavigationContextFixtures.createDestinationContext(containerContext, parentDestination)
+
+        container.execute(parentContext, NavigationOperation.Open(SyntheticTestKey.asInstance()))
+
+        assertEquals(
+            expected = listOf(parentInstance.id),
+            actual = container.backstack.map { it.id },
+            message = "Synthetic close must not affect the backstack of whichever destination opened it",
+        )
+    }
+
+    @Test
+    fun `Calling an outcome method after the synthetic finished throws already-finished`() = runEnroTest {
+        // Simulates the "block launched a coroutine that outlived the
+        // block" case. We can't easily await a real coroutine in a test,
+        // so we capture the scope and invoke an outcome method after the
+        // dispatcher has moved on — same shape, same failure mode.
+        var capturedScope: dev.enro.ui.destinations.SyntheticDestinationScope<SyntheticTestKey>? = null
+        EnroTest.getCurrentNavigationController().addModule(
+            createNavigationModule {
+                destination<SyntheticTestKey>(
+                    syntheticDestination<SyntheticTestKey> {
+                        capturedScope = this
+                        // Falling through — dispatcher will mark this as silent close.
+                    }
+                )
+            }
+        )
+
+        openSynthetic(SyntheticTestKey.asInstance())
+
+        val scope = requireNotNull(capturedScope) { "scope should have been captured by the block" }
+        val error = kotlin.runCatching { scope.close() }.exceptionOrNull()
+        assertTrue(
+            actual = error is IllegalStateException,
+            message = "Late outcome call after fall-through should throw IllegalStateException; was: ${error?.let { it::class.simpleName }}",
+        )
+        assertTrue(
+            actual = error?.message?.contains("already finished") == true,
+            message = "Error message should mention the synthetic already finished; was: ${error?.message}",
+        )
+    }
+
+    @Test
     fun `Synthetic completeFrom forwards result-channel routing to the chosen destination`() = runEnroTest {
         val forwarded = ResultBearingSyntheticTestKey()
         EnroTest.getCurrentNavigationController().addModule(

--- a/enro-runtime/src/commonTest/kotlin/dev/enro/SyntheticDestinationTests.kt
+++ b/enro-runtime/src/commonTest/kotlin/dev/enro/SyntheticDestinationTests.kt
@@ -13,18 +13,11 @@ import dev.enro.test.fixtures.NavigationDestinationFixtures
 import dev.enro.test.runEnroTest
 import dev.enro.ui.destinations.SyntheticDestination
 import dev.enro.ui.destinations.complete
-import dev.enro.ui.destinations.completeFrom
 import dev.enro.ui.destinations.isSyntheticDestination
 import dev.enro.ui.destinations.syntheticDestination
 import dev.enro.ui.navigationDestination
 import kotlinx.serialization.Serializable
-import kotlin.test.AfterTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNull
-import kotlin.test.assertSame
-import kotlin.test.assertTrue
+import kotlin.test.*
 
 /**
  * Coverage for [SyntheticDestination] and its registered interceptor.
@@ -163,7 +156,7 @@ class SyntheticDestinationTests {
     }
 
     @Test
-    fun `Synthetic open(otherKey) opens that key on the originating container`() = runEnroTest {
+    fun `Synthetic open otherKey opens that key on the originating container`() = runEnroTest {
         val targetKey = NavigationKeyFixtures.SimpleKey()
         EnroTest.getCurrentNavigationController().addModule(
             createNavigationModule {
@@ -210,7 +203,7 @@ class SyntheticDestinationTests {
     }
 
     @Test
-    fun `Synthetic complete(result) registers a Completed result with that value`() = runEnroTest {
+    fun `Synthetic complete with result registers a Completed result with that value`() = runEnroTest {
         EnroTest.getCurrentNavigationController().addModule(
             createNavigationModule {
                 destination<ResultBearingSyntheticTestKey>(

--- a/enro-runtime/src/commonTest/kotlin/dev/enro/SyntheticDestinationTests.kt
+++ b/enro-runtime/src/commonTest/kotlin/dev/enro/SyntheticDestinationTests.kt
@@ -4,19 +4,25 @@ package dev.enro
 
 import androidx.compose.material3.Text
 import dev.enro.controller.createNavigationModule
+import dev.enro.result.NavigationResult
+import dev.enro.result.NavigationResultChannel
 import dev.enro.test.EnroTest
 import dev.enro.test.NavigationKeyFixtures
 import dev.enro.test.fixtures.NavigationContextFixtures
 import dev.enro.test.fixtures.NavigationDestinationFixtures
 import dev.enro.test.runEnroTest
 import dev.enro.ui.destinations.SyntheticDestination
+import dev.enro.ui.destinations.complete
+import dev.enro.ui.destinations.completeFrom
 import dev.enro.ui.destinations.isSyntheticDestination
 import dev.enro.ui.destinations.syntheticDestination
 import dev.enro.ui.navigationDestination
 import kotlinx.serialization.Serializable
+import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
@@ -31,8 +37,18 @@ import kotlin.test.assertTrue
  * recognises the open, replaces it with a SideEffect that invokes the
  * synthetic block, and the destination never reaches the backstack.
  * It's the redirect / fire-and-forget primitive in Enro.
+ *
+ * The block can fall through (pure side-effect bridge) or short-circuit by
+ * calling one of the outcome methods on the scope (`open`, `close`,
+ * `complete`, `completeFrom`). Outcome methods throw a sentinel that the
+ * dispatcher catches and converts to a [NavigationOperation].
  */
 class SyntheticDestinationTests {
+
+    @AfterTest
+    fun clearPendingResults() {
+        NavigationResultChannel.pendingResults.value = emptyMap()
+    }
 
     @Test
     fun `isSyntheticDestination returns true for instances bound to a synthetic destination`() = runEnroTest {
@@ -93,17 +109,7 @@ class SyntheticDestinationTests {
             }
         )
 
-        val rootContext = NavigationContextFixtures.createRootContext()
-        val containerContext = NavigationContextFixtures.createContainerContext(rootContext)
-        val container = containerContext.container
-        container.setFilter(acceptAll())
-        container.addInterceptor(SyntheticDestination.interceptor)
-
-        val sourceDestination = NavigationDestinationFixtures.create(NavigationKeyFixtures.SimpleKey())
-        val destinationContext = NavigationContextFixtures.createDestinationContext(containerContext, sourceDestination)
-
-        val syntheticInstance = SyntheticTestKey.asInstance()
-        container.execute(destinationContext, NavigationOperation.Open(syntheticInstance))
+        val container = openSynthetic(SyntheticTestKey.asInstance())
 
         assertEquals(
             expected = 1,
@@ -111,21 +117,181 @@ class SyntheticDestinationTests {
             message = "Synthetic block should have been invoked exactly once for the Open",
         )
         assertSame(
-            expected = destinationContext,
+            expected = container.destinationContext,
             actual = capturedContext,
             message = "Synthetic block's scope.context should be the originating fromContext",
         )
-        assertSame(
-            expected = syntheticInstance,
-            actual = capturedInstance,
-            message = "Synthetic block's scope.instance should be the original instance from the Open",
-        )
         assertEquals(
             expected = 0,
-            actual = container.backstack.size,
+            actual = container.container.backstack.size,
             message = "Synthetic destinations must never reach the container backstack",
         )
+        assertEquals(
+            expected = SyntheticTestKey.asInstance().key,
+            actual = capturedInstance?.key,
+            message = "Synthetic block's scope.instance should carry the original key",
+        )
     }
+
+    @Test
+    fun `Synthetic falling through with no outcome leaves the backstack untouched and registers no result`() = runEnroTest {
+        EnroTest.getCurrentNavigationController().addModule(
+            createNavigationModule {
+                destination<SyntheticTestKey>(
+                    syntheticDestination<SyntheticTestKey> {
+                        // pure side-effect bridge — no outcome method called
+                    }
+                )
+            }
+        )
+        val resultId = NavigationResultChannel.Id(ownerId = "owner", resultId = "ch")
+        val syntheticInstance = SyntheticTestKey.asInstance().apply {
+            metadata.set(NavigationResultChannel.ResultIdKey, resultId)
+        }
+
+        val container = openSynthetic(syntheticInstance)
+
+        assertEquals(
+            expected = 0,
+            actual = container.container.backstack.size,
+            message = "Backstack must remain empty when synthetic falls through with no outcome",
+        )
+        assertNull(
+            actual = NavigationResultChannel.pendingResults.value[resultId],
+            message = "Falling through should not register any result for the synthetic's channel",
+        )
+    }
+
+    @Test
+    fun `Synthetic open(otherKey) opens that key on the originating container`() = runEnroTest {
+        val targetKey = NavigationKeyFixtures.SimpleKey()
+        EnroTest.getCurrentNavigationController().addModule(
+            createNavigationModule {
+                destination<SyntheticTestKey>(
+                    syntheticDestination<SyntheticTestKey> { open(targetKey) }
+                )
+                destination<NavigationKeyFixtures.SimpleKey>(
+                    navigationDestination<NavigationKeyFixtures.SimpleKey> { Text("target") }
+                )
+            }
+        )
+
+        val container = openSynthetic(SyntheticTestKey.asInstance())
+
+        val keys = container.container.backstack.map { it.key }
+        assertEquals(
+            expected = listOf(targetKey),
+            actual = keys,
+            message = "Synthetic open(target) should have produced an Open(target) on the originating container; got: $keys",
+        )
+    }
+
+    @Test
+    fun `Synthetic close registers a Closed result for the synthetic's instance`() = runEnroTest {
+        EnroTest.getCurrentNavigationController().addModule(
+            createNavigationModule {
+                destination<SyntheticTestKey>(
+                    syntheticDestination<SyntheticTestKey> { close() }
+                )
+            }
+        )
+        val resultId = NavigationResultChannel.Id(ownerId = "owner", resultId = "ch")
+        val syntheticInstance = SyntheticTestKey.asInstance().apply {
+            metadata.set(NavigationResultChannel.ResultIdKey, resultId)
+        }
+
+        openSynthetic(syntheticInstance)
+
+        val pending = NavigationResultChannel.pendingResults.value[resultId]
+        assertTrue(
+            actual = pending is NavigationResult.Closed,
+            message = "Synthetic close() should register a Closed result; got: ${pending?.let { it::class.simpleName }}",
+        )
+    }
+
+    @Test
+    fun `Synthetic complete(result) registers a Completed result with that value`() = runEnroTest {
+        EnroTest.getCurrentNavigationController().addModule(
+            createNavigationModule {
+                destination<ResultBearingSyntheticTestKey>(
+                    syntheticDestination<ResultBearingSyntheticTestKey> { complete("from synthetic") }
+                )
+            }
+        )
+        val resultId = NavigationResultChannel.Id(ownerId = "owner", resultId = "ch")
+        val syntheticInstance = ResultBearingSyntheticTestKey().asInstance().apply {
+            metadata.set(NavigationResultChannel.ResultIdKey, resultId)
+        }
+
+        openSynthetic(syntheticInstance)
+
+        val pending = NavigationResultChannel.pendingResults.value[resultId]
+        assertTrue(
+            actual = pending is NavigationResult.Completed<*>,
+            message = "Synthetic complete(result) should register a Completed result",
+        )
+        assertEquals(
+            expected = "from synthetic",
+            actual = (pending as NavigationResult.Completed<*>).data,
+            message = "Completed result's payload should match what the synthetic passed to complete()",
+        )
+    }
+
+    @Test
+    fun `Synthetic completeFrom forwards result-channel routing to the chosen destination`() = runEnroTest {
+        val forwarded = ResultBearingSyntheticTestKey()
+        EnroTest.getCurrentNavigationController().addModule(
+            createNavigationModule {
+                destination<ResultBearingSyntheticTestKey>(
+                    navigationDestination<ResultBearingSyntheticTestKey> { Text("forwarded") }
+                )
+                destination<ForwardingSyntheticKey>(
+                    syntheticDestination<ForwardingSyntheticKey> { completeFrom(forwarded) }
+                )
+            }
+        )
+        val resultId = NavigationResultChannel.Id(ownerId = "owner", resultId = "ch")
+        val syntheticInstance = ForwardingSyntheticKey().asInstance().apply {
+            metadata.set(NavigationResultChannel.ResultIdKey, resultId)
+        }
+
+        val container = openSynthetic(syntheticInstance)
+
+        // The forwarded key should have landed in the container's backstack…
+        val landed = container.container.backstack.singleOrNull()
+        assertTrue(
+            actual = landed != null && landed.key == forwarded,
+            message = "completeFrom should have opened the forwarded key; backstack was: ${container.container.backstack.map { it.key }}",
+        )
+        // …and the forwarded instance must carry the synthetic's original ResultIdKey, so
+        // when *it* completes, the original caller's channel gets the result.
+        assertEquals(
+            expected = resultId,
+            actual = landed?.metadata?.get(NavigationResultChannel.ResultIdKey),
+            message = "completeFrom must copy the synthetic's ResultIdKey onto the forwarded instance so result routing reaches the original caller",
+        )
+    }
+}
+
+private data class OpenedSyntheticContainer(
+    val container: NavigationContainer,
+    val destinationContext: NavigationContext,
+)
+
+private fun openSynthetic(
+    syntheticInstance: NavigationKey.Instance<NavigationKey>,
+): OpenedSyntheticContainer {
+    val rootContext = NavigationContextFixtures.createRootContext()
+    val containerContext = NavigationContextFixtures.createContainerContext(rootContext)
+    val container = containerContext.container
+    container.setFilter(acceptAll())
+    container.addInterceptor(SyntheticDestination.interceptor)
+
+    val sourceDestination = NavigationDestinationFixtures.create(NavigationKeyFixtures.SimpleKey())
+    val destinationContext = NavigationContextFixtures.createDestinationContext(containerContext, sourceDestination)
+
+    container.execute(destinationContext, NavigationOperation.Open(syntheticInstance))
+    return OpenedSyntheticContainer(container, destinationContext)
 }
 
 @Serializable
@@ -133,3 +299,9 @@ data object SyntheticTestKey : NavigationKey
 
 @Serializable
 data object RegularSyntheticTestKey : NavigationKey
+
+@Serializable
+class ResultBearingSyntheticTestKey : NavigationKey.WithResult<String>
+
+@Serializable
+class ForwardingSyntheticKey : NavigationKey.WithResult<String>


### PR DESCRIPTION
## Summary

Closes the long-standing `SyntheticDestinationScope.kt:10-12` TODO that admitted the scope had no structured way to express its outcome:

> `// TODO: Need to add functionality to do a replace/close/complete/completeFrom from the context of a synthetic destination scope (to allow for "forwardResult" and "setResult") type functionality that previously existed in Enro 2.x`

The scope now exposes outcome methods that throw a sentinel and return `Nothing`, mirroring the `OnNavigationKeyOpenedScope` pattern already used by interceptors. The synthetic dispatcher catches the sentinel and converts it to a `NavigationOperation`. Blocks that don't call an outcome method continue to work as pure side-effect bridges.

## Three things synthetics are for

The shape of this API is driven by three concrete use cases:

- **External side-effects masquerading as navigation** — e.g. `OpenWebDestination(url)` that launches Chrome Custom Tabs. The block runs imperative work; no Enro state changes. The synthetic instance never lands in any backstack.
- **"Decider" synthetics** — e.g. `SelectDate : NavigationKey.WithResult<LocalDate>` that decides at runtime which of `SelectDateVersionOne` / `SelectDateVersionTwo` should fulfil the contract. The synthetic forwards to the chosen destination, whose eventual result routes back to whoever originally opened the synthetic.
- **Compound nav actions** — e.g. `LogoutAction` that clears a session and opens `Home`.

In code:

```kotlin
syntheticDestination<OpenWebDestination> {
    val activity = context.findActivity()
    activity.startActivity(buildChromeCustomTabsIntent(key.url))
    // no outcome → block returns → Enro takes no further nav action
}

syntheticDestination<SelectDate> {                       // : NavigationKey.WithResult<LocalDate>
    if (featureFlag) completeFrom(SelectDateVersionOne)  // routes result back
    else completeFrom(SelectDateVersionTwo)
}

syntheticDestination<LogoutAction> {
    sessionManager.clearSession()
    open(Home)
}
```

## The outcome API

`SyntheticDestinationScope<K : NavigationKey>` gets the following class methods, each throwing `SyntheticDestinationOutcome` and returning `Nothing`:

- `open(key)` / `open(key.withMetadata(...))` — open another key in place of the synthetic.
- `close()` — register a `Closed` result against whoever opened the synthetic.
- `complete()` — register a `Completed` result with no payload (non-result keys only).
- `completeFrom(key: NavigationKey)` — open the key with the synthetic's `ResultIdKey` metadata copied across (so the forwarded key's completion routes back to the original caller).

For `SyntheticDestinationScope<out NavigationKey.WithResult<R>>`, extension functions add:

- `complete(result: R)` — typed result variant.
- `completeFrom(key: NavigationKey.WithResult<R>)` — must forward to a key with matching result type.

Plus `@Deprecated(ERROR)` shadow extensions block the no-arg `complete()` and the non-result `completeFrom(NavigationKey)` on result-bearing scopes, so the result contract can't accidentally be broken. Same trick `NavigationHandle` and `NavigationOperation.Complete` use.

The class method on the scope is `completeFrom(key: NavigationKey)` rather than `forwardResult` (which is what enro 2.x called it) — `completeFrom` aligns with `NavigationHandle.completeFrom(key)` from normal navigation, which has the same semantic.

## Why throw-based rather than explicit `Outcome` return type

Considered both:

1. **Consistency** with existing `OnNavigationKeyOpenedScope` / `OnNavigationKeyClosedScope` / `OnNavigationKeyCompletedScope` (`continueWithOpen`, `cancel`, `cancelAnd`, `replaceWith`). Same idiom, less to learn.
2. **Imperative composition** — `if (cond) open(Foo)` short-circuits naturally; an explicit return type forces awkward `return` keyword usage from inside conditionals.
3. **Single-outcome enforcement is free** — once any outcome method throws, the block is over. No way to accidentally chain `open(A)` then `complete(B)`.

Cost is the usual one for control-flow-via-exception (mildly surprising to readers), mitigated by the existing precedent.

## Required core change: off-backstack Close/Complete

`NavigationInterceptor.processOperations` previously dropped Close/Complete operations whose target instance wasn't in the container's backstack, with a warning. That made sense as a safety net but it actively blocked synthetic outcomes — the synthetic instance is never in any backstack by design, so its Close/Complete operations were silently filtered out and the result channel never fired.

This PR removes the early-return. Flow-step stripping (the `completedResultIds` bookkeeping) still works for backstack-resident result owners. The warning is removed since "off-backstack Close" is now a legitimate pattern, not a bug signal.

## What's NOT in this PR

- **Lifecycle-bearing synthetics** — explored in the design discussion as a way to give synthetics their own `LifecycleOwner` / `ViewModelStoreOwner` for long-running async work, with rendering skipped. Fans out into too many design decisions (block-runs-when, auto-close, render filtering, result-channel ownership, persistence) — captured as a Tier-4 follow-up. The throw-based API ships here is forward-compatible with either implementation model.
- **Prohibiting async work in synthetics entirely** — separate future direction Isaac is also considering (synthetics as lightweight overlays, async work happens outside them). Also captured as a Tier-4 follow-up.

## Compat migration

`enro-compat`'s `sendResult(result)` and `forwardResult(navigationKey, direction)` are now thin `@Deprecated` wrappers around the new `complete(result)` / `completeFrom(navigationKey)`. Behaviour is preserved (same Completed result registration; same forwarded-instance with copied `ResultIdKey`) so existing v2 callers keep working with a deprecation hint. The v2 `direction` parameter is now ignored — push vs present is no longer modelled as a per-operation flag in v3.

## Test plan

- [ ] `./gradlew :enro-runtime:desktopTest` — full suite green; 5 new tests in `SyntheticDestinationTests` cover each outcome path plus the fall-through (side-effect-bridge) case.
- [ ] `./gradlew :enro-runtime:compileKotlinWasmJs` — wasmJs target compiles.
- [ ] `./gradlew :enro-compat:compileDebugKotlinAndroid` — compat module compiles against the new outcome methods.
- [ ] Spot-check that existing `ResultChannelTests` (the result-channel coverage that exercises the `processOperations` path) still passes — the off-backstack change preserves the warned-but-not-dropped semantic for genuine flow-step-stripping cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)