### PR TITLE
Synthetic destinations: in-place rewrite + explicit sideEffect outcome

### DIFF
--- a/docs/ghpages/docs/advanced/synthetic-destinations.md
+++ b/docs/ghpages/docs/advanced/synthetic-destinations.md
@@ -70,20 +70,61 @@ the key and instance available, plus the outcome methods covered below.
 ## The outcome methods
 
 Each method ends the synthetic by deciding what should happen next. They
-all return `Nothing` — calling one short-circuits the block.
+all return `Nothing` — calling one short-circuits the block. They split
+into two kinds: **pure outcomes** that are rewritten in place as the
+synthetic's surrounding `processOperations` pass runs, and a
+**side-effect outcome** that runs deferred after the pass settles.
+
+### Pure outcomes — rewritten in place
 
 | Method | What it does |
 |---|---|
-| `open(key)` | Opens `key` on the same container the synthetic was opened on. The synthetic instance itself never lands on any backstack. |
+| `open(key)` | Opens `key` on the same container the synthetic was opened on. The dispatcher rewrites the original `Open(synthetic)` into `Open(key)` inside `processOperations`, so the new operation flows through the interceptor chain in the same pass. Ordering is preserved when synthetics appear in an initial backstack alongside normal destinations. |
 | `close()` | Ends the synthetic and registers a `Closed` result against whoever opened the synthetic. The caller's `onClosed` callback fires. |
 | `closeSilently()` | Same as `close()` but the result-channel callback does **not** fire. Use when the caller doesn't need to be notified. |
 | `complete()` | Ends the synthetic and registers a `Completed` result with no payload. Only available for non-result keys. |
 | `complete(result)` | Same as `complete()` but with a typed payload. Only available when the synthetic's key implements `NavigationKey.WithResult<R>`. |
 | `completeFrom(key)` | Opens `key` and routes *its* eventual completion back to whoever opened the synthetic. The synthetic doesn't produce the result; the forwarded key does. |
 
+### Side-effect outcome — runs deferred
+
+| Method | What it does |
+|---|---|
+| `sideEffect { ... }` | The block runs in `afterExecution`, with a [`SyntheticSideEffectScope`](#side-effect-scope) receiver carrying `context`, `container`, `instance`, and `key`. The synthetic is treated as silently closed once the side effect dispatches. Use this when you need platform handles, the container reference, or any imperative work that doesn't fit a single navigation operation. |
+
 The methods throw a sentinel exception that the synthetic dispatcher
 catches and converts into a `NavigationOperation`. Don't catch
 `Throwable` inside a synthetic block — you'll swallow the outcome.
+
+## Pure outcomes vs side effects
+
+The split matters because the two kinds run at different points in the
+operation lifecycle.
+
+A **pure outcome** is a deterministic rewrite of the synthetic's `Open`.
+The dispatcher catches the outcome and returns the equivalent operation
+from inside its interceptor — so the rewrite is part of the same
+`processOperations` pass that handled the original `Open(synthetic)`.
+For example, if an initial backstack is `[ASynthetic, B]` and the
+synthetic opens `Target`, the resulting backstack is `[Target, B]` —
+the synthetic's outcome takes the synthetic's slot in the queue, not the
+end of the queue.
+
+A **side-effect outcome** runs deferred, in `afterExecution`. By the time
+the block runs, every other operation in the same pass has already
+settled. That's the point at which you can safely:
+
+- Touch platform handles (find an `Activity`, get a Compose
+  `WindowInfo`, etc.).
+- Read or rewrite the container's backstack
+  (`container.execute(context, NavigationOperation.SetBackstack(...))`).
+- Make any other imperative call that doesn't fit a single
+  `NavigationOperation`.
+
+The two recipes that ship in `recipes/synthetic` illustrate the split:
+the auth gate and profile decider both use pure outcomes; the external
+URL launcher uses `sideEffect { ... }` because it bridges to a non-Enro
+API.
 
 ## Falling through
 
@@ -92,18 +133,13 @@ treated as a **silent close**. No result-channel callback fires; no
 navigation operation is dispatched against the synthetic's instance. The
 block ran, did its thing, and Enro doesn't need to do anything further.
 
-```kotlin
-@NavigationDestination(OpenExternalUrl::class)
-val openExternalUrl = syntheticDestination<OpenExternalUrl> {
-    val activity = context.findActivity()
-    activity.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(key.url)))
-    // no outcome method — falls through to silent close
-}
-```
-
-This is the most common shape for pure side-effect bridges. Callers
-generally don't subscribe to a result for these, so the silent close
-is the right default.
+This is the default for synthetics that only do pure side effects — but
+note that in the current model you should prefer `sideEffect { ... }`
+for that work, so you get explicit access to `container` and `context`
+deferred to the right point. Pure synthetics that genuinely do *no*
+imperative work and only return a fixed outcome (like a decider that
+always picks one of two destinations) tend to be one-line bodies that
+short-circuit through `open()` or `completeFrom(...)`.
 
 ## Forwarding results with `completeFrom`
 
@@ -181,20 +217,51 @@ synthetic" mode but isn't on the current roadmap.
 
 ## Accessing the originating context
 
-The scope exposes `context: NavigationContext` — the context from which
-the synthetic was opened. Use it when the block needs platform handles
-that aren't part of Enro itself:
+### From the pure scope — reads only
+
+`SyntheticDestinationScope<K>` exposes `context: NavigationContext` and
+the derived `destinationContext`. These are intended for **reads**:
+inspecting `controller`, walking parent contexts, checking which
+destination opened the synthetic. They're available so a pure outcome
+can be informed by the surrounding navigation state.
+
+You can technically reach `context.controller` and other writable handles
+from inside a pure block, but doing so runs while the container's
+execute mutex is held — direct `controller.execute(...)` or
+`container.execute(...)` calls deadlock. That's the framework signalling
+that you should be using `sideEffect { ... }` instead.
+
+### From the side-effect scope — full access
+
+`SyntheticSideEffectScope<K>` (the receiver of the `sideEffect` block)
+exposes `context`, `container`, `instance`, and `key`. By the time the
+side-effect block runs, the mutex is released and the backstack has
+settled, so imperative work is safe:
 
 ```kotlin
 @NavigationDestination(OpenExternalUrl::class)
 val openExternalUrl = syntheticDestination<OpenExternalUrl> {
-    val activity = context.findActivity()  // Android extension
-    activity.startActivity(Intent(ACTION_VIEW, Uri.parse(key.url)))
+    sideEffect {
+        val activity = context.findActivity()  // Android extension
+        activity.startActivity(Intent(ACTION_VIEW, Uri.parse(key.url)))
+    }
+}
+
+@NavigationDestination(DeepLinkResolver::class)
+val deepLinkResolver = syntheticDestination<DeepLinkResolver> {
+    sideEffect {
+        val resolved = context.controller.getNavigationKeyFromPath(key.url)
+            ?: return@sideEffect
+        container.execute(
+            context = context,
+            operation = NavigationOperation.SetBackstack(
+                currentBackstack = container.backstack,
+                targetBackstack = backstackOf(Home.asInstance(), resolved.asInstance()),
+            ),
+        )
+    }
 }
 ```
-
-`context.controller` reaches the `EnroController`, which is the entry
-point to the path-binding APIs, registered serializers, and so on.
 
 ## See also
 

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/interceptor/NavigationInterceptor.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/interceptor/NavigationInterceptor.kt
@@ -60,7 +60,22 @@ public abstract class NavigationInterceptor {
             ).toMutableList()
 
             val backstackById = containerContext.container.backstack.associateBy { it.id }
+            // Guards against infinite interceptor loops -- chiefly synthetic
+            // destinations whose outcomes (directly or transitively) re-open
+            // the same synthetic. Real navigation passes rarely exceed a few
+            // dozen iterations; 256 leaves room for deep aggregates without
+            // letting a runaway loop hang the whole controller.
+            val maxIterations = 256
+            var iterations = 0
             while (toProcess.isNotEmpty()) {
+                if (++iterations > maxIterations) {
+                    error(
+                        "Navigation interceptor processing exceeded $maxIterations iterations. " +
+                            "This usually means a synthetic destination's outcome opens (directly or " +
+                            "transitively) the same synthetic again, or an interceptor is rewriting " +
+                            "an operation back to itself. Most recent operation: ${toProcess.first()}"
+                    )
+                }
                 val operation = toProcess.removeAt(0)
                 val intercepted = when (operation) {
                     // If we're getting an Open operation and the backstack already contains

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticDestination.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticDestination.kt
@@ -23,21 +23,30 @@ internal class SyntheticDestination<K : NavigationKey>(
                 operation: NavigationOperation.Open<NavigationKey>,
             ): NavigationOperation? {
                 if (!isSyntheticDestination(operation.instance)) return operation
-                return NavigationOperation.SideEffect {
-                    executeSynthetic(
-                        fromContext = fromContext,
-                        containerContext = containerContext,
-                        instance = operation.instance,
-                    )
-                }
+                return resolveSyntheticOutcome(
+                    fromContext = fromContext,
+                    containerContext = containerContext,
+                    instance = operation.instance,
+                )
             }
         }
 
-        internal fun executeSynthetic(
+        /**
+         * Runs the synthetic's block synchronously and converts the outcome
+         * into a [NavigationOperation] that takes the place of the original
+         * `Open(synthetic)` in the surrounding `processOperations` pass.
+         *
+         * Pure outcomes (open/close/complete/completeFrom) become the
+         * equivalent operation; the side-effect outcome becomes a
+         * [NavigationOperation.SideEffect] whose body constructs the
+         * [SyntheticSideEffectScope] and invokes the user block in
+         * `afterExecution`.
+         */
+        private fun resolveSyntheticOutcome(
             fromContext: NavigationContext,
             containerContext: ContainerContext,
             instance: NavigationKey.Instance<NavigationKey>,
-        ) {
+        ): NavigationOperation {
             val controller = fromContext.controller
             val bindings = controller.bindings.bindingFor(instance = instance)
             val syntheticDestination = bindings.provider.peekMetadata(instance)[SyntheticDestinationKey]
@@ -53,13 +62,9 @@ internal class SyntheticDestination<K : NavigationKey>(
             } catch (outcome: SyntheticDestinationOutcome) {
                 outcome
             }
-
-            // If the block fell through without calling an outcome method, settle
-            // the scope on a silent close. This locks the scope so any subsequent
-            // call from a stray coroutine throws the "already finished" error.
             val effectiveOutcome = thrown ?: scope.finalizeAsSilentCloseIfNoOutcome()
 
-            val operation = when (effectiveOutcome) {
+            return when (effectiveOutcome) {
                 is SyntheticDestinationOutcome.Open ->
                     NavigationOperation.Open(effectiveOutcome.target)
                 is SyntheticDestinationOutcome.Close ->
@@ -76,8 +81,15 @@ internal class SyntheticDestination<K : NavigationKey>(
                 }
                 is SyntheticDestinationOutcome.CompleteFrom ->
                     NavigationOperation.CompleteFrom(instance, effectiveOutcome.target)
+                is SyntheticDestinationOutcome.SideEffect -> NavigationOperation.SideEffect {
+                    val sideEffectScope = SyntheticSideEffectScope(
+                        context = fromContext,
+                        container = containerContext.container,
+                        instance = instance,
+                    )
+                    effectiveOutcome.block(sideEffectScope)
+                }
             }
-            containerContext.container.execute(fromContext, operation)
         }
     }
 }

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticDestinationOutcome.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticDestinationOutcome.kt
@@ -4,12 +4,25 @@ import dev.enro.NavigationKey
 
 /**
  * Sentinel exception thrown by the outcome methods on [SyntheticDestinationScope]
- * (e.g. `open`, `close`, `closeSilently`, `complete`, `completeFrom`) to signal
- * the synthetic's decision back up to the synthetic dispatcher. The dispatcher
- * catches the subclass and converts it to the corresponding
+ * (e.g. `open`, `close`, `closeSilently`, `complete`, `completeFrom`, `sideEffect`)
+ * to signal the synthetic's decision back up to the synthetic dispatcher. The
+ * dispatcher catches the subclass and converts it to the corresponding
  * [dev.enro.NavigationOperation].
  *
- * Throwing for control flow mirrors the pattern used by [InterceptorBuilderResult][dev.enro.interceptor.builder.InterceptorBuilderResult]
+ * Outcomes split into two kinds:
+ *
+ *  - **Pure outcomes** ([Open], [Close], [Complete], [CompleteFrom]) become an
+ *    in-place rewrite of the original `Open(synthetic)` — the dispatcher returns
+ *    the equivalent operation from inside its interceptor, so the rewrite is
+ *    applied during the same `processOperations` pass. Ordering is preserved.
+ *  - **The side-effect outcome** ([SideEffect]) is dispatched as a
+ *    `NavigationOperation.SideEffect`, which runs in `afterExecution` once
+ *    every other operation in the current pass has settled. Used when the
+ *    synthetic needs platform context, the container reference, or arbitrary
+ *    imperative work.
+ *
+ * Throwing for control flow mirrors the pattern used by
+ * [InterceptorBuilderResult][dev.enro.interceptor.builder.InterceptorBuilderResult]
  * — it lets the scope methods return [Nothing] so the synthetic block can
  * short-circuit naturally from inside conditionals.
  */
@@ -30,5 +43,17 @@ internal sealed class SyntheticDestinationOutcome : RuntimeException() {
 
     internal class CompleteFrom(
         val target: NavigationKey.Instance<NavigationKey>,
+    ) : SyntheticDestinationOutcome()
+
+    /**
+     * The block runs deferred, in `afterExecution` of the operation processing
+     * pass that intercepted the synthetic. By that point any other operations
+     * in the same pass have settled, so the side effect sees the post-rewrite
+     * backstack state. The dispatcher wraps this in a
+     * [dev.enro.NavigationOperation.SideEffect] and constructs the
+     * [SyntheticSideEffectScope] receiver when the side effect actually runs.
+     */
+    internal class SideEffect(
+        val block: SyntheticSideEffectScope<NavigationKey>.() -> Unit,
     ) : SyntheticDestinationOutcome()
 }

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticDestinationScope.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticDestinationScope.kt
@@ -3,6 +3,7 @@ package dev.enro.ui.destinations
 import dev.enro.NavigationContext
 import dev.enro.NavigationKey
 import dev.enro.asInstance
+import dev.enro.context.AnyNavigationContext
 import dev.enro.context.ContainerContext
 import dev.enro.context.DestinationContext
 import dev.enro.context.RootContext
@@ -73,6 +74,13 @@ public class SyntheticDestinationScope<K : NavigationKey> @PublishedApi internal
             is ContainerContext -> context.activeChild
             is RootContext -> context.activeChild?.activeChild
         }
+
+    @Deprecated("Use destinationContext or context instead for greater clarity about the context being used")
+    public val navigationContext: AnyNavigationContext
+        get() = context
+
+    @Deprecated("Use instance")
+    public val instruction: NavigationKey.Instance<K> = instance
 
     /**
      * The outcome the synthetic settled on. Null while the block is running

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticDestinationScope.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticDestinationScope.kt
@@ -3,7 +3,6 @@ package dev.enro.ui.destinations
 import dev.enro.NavigationContext
 import dev.enro.NavigationKey
 import dev.enro.asInstance
-import dev.enro.context.AnyNavigationContext
 import dev.enro.context.ContainerContext
 import dev.enro.context.DestinationContext
 import dev.enro.context.RootContext
@@ -13,13 +12,9 @@ import dev.enro.context.RootContext
  * destination is a [NavigationKey] that, when opened, runs the block instead
  * of rendering a UI; the synthetic instance never reaches a backstack.
  *
- * The block can return without calling any outcome method — in that case the
- * synthetic acts purely as a side-effect bridge (e.g. launching an `Intent`
- * to Chrome Custom Tabs) and the synthetic is considered to have closed
- * silently. No result-channel callback fires for the original caller.
- *
- * Alternatively, the block can short-circuit by calling one of the outcome
- * methods:
+ * Outcomes split into **pure** outcomes (synchronous, in-place rewrite of
+ * the original `Open(synthetic)`) and a **side-effect** outcome (deferred
+ * imperative work with platform/container access). The pure outcomes are:
  *
  * - [open] — open another [NavigationKey] in place of the synthetic.
  * - [close] — register a `Closed` result for whoever called the synthetic.
@@ -27,32 +22,51 @@ import dev.enro.context.RootContext
  * - [complete] — register a `Completed` result. For result-bearing
  *   synthetics see the `complete(result: T)` extension.
  * - [completeFrom] — open another key and have *its* completion fulfil the
- *   synthetic's contract. Useful for "decider" synthetics that pick one of
- *   several destinations at runtime.
+ *   synthetic's contract.
+ *
+ * Pure outcomes flow through the same interceptor pipeline as any other
+ * operation, in order, in the same processing pass. That preserves
+ * ordering when synthetics appear in an initial backstack alongside
+ * normal destinations.
+ *
+ * For everything else — launching a system browser, rewriting the
+ * container's backstack, calling out to a non-Enro API — reach for
+ * [sideEffect]. The side-effect block runs deferred, has access to the
+ * originating [NavigationContext] and the target [dev.enro.NavigationContainer],
+ * and never blocks the operation pipeline.
+ *
+ * The block can fall through without calling any outcome method — that's
+ * treated as a silent close (no result-channel callback fires, no
+ * operation is dispatched against the backstack).
  *
  * Each outcome method throws a sentinel and returns [Nothing], so calls
  * inside conditionals flow naturally without needing explicit `return`.
- *
- * The scope tracks the outcome it settles on. Once an outcome is set —
- * whether by an explicit method call inside the block, or by the dispatcher
- * defaulting to a silent close after the block returns — any subsequent
- * call (typically from an async coroutine that outlived the block) throws
- * a clear error instead of silently double-handling.
+ * The scope tracks the outcome it settles on: once one is set, any further
+ * outcome call from an async coroutine that outlived the block throws a
+ * clear "already finished" error rather than silently double-handling.
  */
 public class SyntheticDestinationScope<K : NavigationKey> @PublishedApi internal constructor(
-    // context is the NavigationContext that is executing this SyntheticDestination,
-    // which could be a RootContext, ContainerContext or DestinationContext depending on how
-    // the synthetic destination was opened
+    /**
+     * The [NavigationContext] the synthetic was opened from. Intended for
+     * reads — inspecting `controller`, walking parent contexts, checking
+     * `activeChild` — to inform the outcome decision. Imperative actions
+     * (calling `controller.execute`, mutating containers) should go through
+     * [sideEffect] instead, which is dispatched after the synthetic's own
+     * outcome has settled.
+     */
     public val context: NavigationContext,
     public val instance: NavigationKey.Instance<K>,
 ) {
     public val key: K = instance.key
 
-    // destinationContext will be the active destination closest to the context,
-    // meaning that if context is a DestinationContext, destinationContext will be that instance,
-    // if context is a ContainerContext, destinationContext will be that container's active context,
-    // and if the context is a RootContext, destinationContext will be the active child of the RootContext's
-    // active ContainerContext
+    /**
+     * The active destination closest to [context]. Read-only convenience —
+     * useful for synthetics that want to know "what screen am I being opened
+     * from?" Walks the context tree: if [context] is a
+     * [DestinationContext] this is that context; if it's a
+     * [ContainerContext], it's the container's active child; if it's a
+     * [RootContext], it's the active child of the root's active container.
+     */
     public val destinationContext: DestinationContext<NavigationKey>?
         get() = when (context) {
             is DestinationContext<*> -> context
@@ -60,18 +74,11 @@ public class SyntheticDestinationScope<K : NavigationKey> @PublishedApi internal
             is RootContext -> context.activeChild?.activeChild
         }
 
-    @Deprecated("Use destinationContext or context instead for greater clarity about the context being used")
-    public val navigationContext: AnyNavigationContext
-        get() = context
-
-    @Deprecated("Use instance")
-    public val instruction: NavigationKey.Instance<K> = instance
-
     /**
-     * The outcome the synthetic settled on. Null while the block is running and
-     * before any method is called; set the first time one of the scope's
-     * outcome methods runs (or by the dispatcher after the block falls through).
-     * Read by the dispatcher; written via [setOutcome].
+     * The outcome the synthetic settled on. Null while the block is running
+     * and before any method is called; set the first time one of the scope's
+     * outcome methods runs (or by the dispatcher after the block falls
+     * through to record a silent close).
      */
     internal var outcome: SyntheticDestinationOutcome? = null
         private set
@@ -80,7 +87,7 @@ public class SyntheticDestinationScope<K : NavigationKey> @PublishedApi internal
      * Records [newOutcome] and throws it. If an outcome is already set,
      * throws an [IllegalStateException] instead — this catches the case
      * where an async coroutine outlived the block and tried to complete /
-     * close the synthetic after the dispatcher already moved on.
+     * close the synthetic after the dispatcher had already moved on.
      */
     internal fun setOutcome(newOutcome: SyntheticDestinationOutcome): Nothing {
         val current = outcome
@@ -115,7 +122,8 @@ public class SyntheticDestinationScope<K : NavigationKey> @PublishedApi internal
     /**
      * End the synthetic's outcome decision by opening another [NavigationKey]
      * in place of this synthetic. The synthetic instance itself never lands
-     * in any backstack.
+     * in any backstack; the dispatcher rewrites the original `Open(synthetic)`
+     * to `Open(key)` inline.
      */
     public fun open(key: NavigationKey): Nothing =
         setOutcome(SyntheticDestinationOutcome.Open(key.asInstance()))
@@ -132,10 +140,9 @@ public class SyntheticDestinationScope<K : NavigationKey> @PublishedApi internal
         setOutcome(SyntheticDestinationOutcome.Close(silent = false))
 
     /**
-     * Close the synthetic without firing the result-channel callback. The
-     * caller's `onClosed` won't run. Use this when the synthetic acts as a
-     * pure side-effect bridge and the original caller doesn't need to know
-     * the synthetic finished.
+     * Close the synthetic without firing the result-channel callback. Use
+     * when the synthetic acted as a pure side-effect bridge and the original
+     * caller doesn't need to know the synthetic finished.
      */
     public fun closeSilently(): Nothing =
         setOutcome(SyntheticDestinationOutcome.Close(silent = true))
@@ -145,8 +152,8 @@ public class SyntheticDestinationScope<K : NavigationKey> @PublishedApi internal
      * result with no payload.
      *
      * For synthetics whose key is a [NavigationKey.WithResult], this no-arg
-     * overload is shadowed by a deprecated-error extension — you must call
-     * the typed `complete(result: T)` extension instead.
+     * overload is shadowed by a deprecated-error extension — call the typed
+     * `complete(result: T)` extension instead.
      */
     public fun complete(): Nothing =
         setOutcome(SyntheticDestinationOutcome.Complete(result = null))
@@ -155,13 +162,34 @@ public class SyntheticDestinationScope<K : NavigationKey> @PublishedApi internal
      * End the synthetic's outcome decision by opening [key] and routing its
      * eventual completion back to whoever opened the synthetic. The
      * synthetic itself doesn't produce the result; the forwarded key does.
-     *
-     * For synthetics whose key is a [NavigationKey.WithResult], the
-     * forwarded key must also be a [NavigationKey.WithResult] of the same
-     * result type — that variant is provided as an extension; this non-result
-     * overload is blocked on result-bearing scopes by a deprecated-error
-     * extension.
      */
     public fun completeFrom(key: NavigationKey): Nothing =
         setOutcome(SyntheticDestinationOutcome.CompleteFrom(key.asInstance()))
+
+    /**
+     * End the synthetic's outcome decision by dispatching a side effect.
+     * The [block] runs deferred, in `afterExecution` of the current
+     * operation pass — meaning every other operation in the same pass has
+     * already settled by the time the block runs. Use this when the
+     * synthetic needs platform handles (e.g. an Android Activity), the
+     * container reference, or any imperative work that doesn't fit a single
+     * navigation operation.
+     *
+     * The side-effect block runs with a [SyntheticSideEffectScope] receiver
+     * carrying `context`, `container`, `instance`, and `key`. From inside
+     * the block you can call `container.execute(context, ...)` to drive
+     * further navigation (including `SetBackstack` for whole-backstack
+     * rewrites). The synthetic itself is treated as silently closed once
+     * the side effect dispatches — no result-channel callback fires.
+     */
+    public fun sideEffect(
+        block: SyntheticSideEffectScope<K>.() -> Unit,
+    ): Nothing {
+        @Suppress("UNCHECKED_CAST")
+        setOutcome(
+            SyntheticDestinationOutcome.SideEffect(
+                block as SyntheticSideEffectScope<NavigationKey>.() -> Unit,
+            )
+        )
+    }
 }

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticSideEffectScope.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticSideEffectScope.kt
@@ -1,0 +1,41 @@
+package dev.enro.ui.destinations
+
+import dev.enro.NavigationContainer
+import dev.enro.NavigationContext
+import dev.enro.NavigationKey
+
+/**
+ * Receiver scope of a [SyntheticDestinationScope.sideEffect] block.
+ *
+ * A side-effect outcome runs deferred — after the dispatcher has rewritten
+ * the synthetic's `Open` and any other operations in the same processing
+ * pass have settled. That's the point at which `context` and `container`
+ * reflect the navigation state the user would expect to see "after" the
+ * synthetic ran, and the point at which imperative work (launching a
+ * browser intent, rewriting the container's backstack, etc.) is safe.
+ *
+ * Reaching for a side effect should be deliberate: the pure outcomes
+ * (`open`, `close`, `complete`, `completeFrom`) on the parent scope
+ * already cover most synthetic patterns. Use a side effect when you need
+ * platform handles (e.g. an Android `Activity`), when you need to read or
+ * mutate the container's backstack, or when you're bridging to a system
+ * outside Enro.
+ */
+public class SyntheticSideEffectScope<K : NavigationKey> @PublishedApi internal constructor(
+    /**
+     * The [NavigationContext] from which the synthetic was originally opened.
+     * Typically a [dev.enro.context.DestinationContext] (the caller's screen)
+     * but may be a [dev.enro.context.ContainerContext] or
+     * [dev.enro.context.RootContext] depending on how the synthetic was opened.
+     */
+    public val context: NavigationContext,
+    /**
+     * The [NavigationContainer] the synthetic's `Open` was dispatched to.
+     * Use `container.execute(context, NavigationOperation.SetBackstack(...))`
+     * to rewrite the backstack from inside a side effect.
+     */
+    public val container: NavigationContainer,
+    public val instance: NavigationKey.Instance<K>,
+) {
+    public val key: K get() = instance.key
+}

--- a/enro-runtime/src/commonTest/kotlin/dev/enro/SyntheticDestinationTests.kt
+++ b/enro-runtime/src/commonTest/kotlin/dev/enro/SyntheticDestinationTests.kt
@@ -324,6 +324,173 @@ class SyntheticDestinationTests {
     }
 
     @Test
+    fun `Pure synthetic outcomes are rewritten in place and preserve initial-backstack ordering`() = runEnroTest {
+        // A synthetic that opens TargetKey, placed as the FIRST entry in an
+        // AggregateOperation alongside RegularKey, should land as
+        // [TargetKey, RegularKey]. The synthetic's outcome must replace
+        // the synthetic's Open in the same processing pass — not be
+        // appended at the end via a separate execute call.
+        val targetKey = NavigationKeyFixtures.SimpleKey()
+        val regularKey = NavigationKeyFixtures.SimpleKey()
+        EnroTest.getCurrentNavigationController().addModule(
+            createNavigationModule {
+                destination<SyntheticTestKey>(
+                    syntheticDestination<SyntheticTestKey> { open(targetKey) }
+                )
+                destination<NavigationKeyFixtures.SimpleKey>(
+                    navigationDestination<NavigationKeyFixtures.SimpleKey> { Text("regular") }
+                )
+            }
+        )
+
+        val rootContext = NavigationContextFixtures.createRootContext()
+        val containerContext = NavigationContextFixtures.createContainerContext(rootContext)
+        val container = containerContext.container
+        container.setFilter(acceptAll())
+        container.addInterceptor(SyntheticDestination.interceptor)
+
+        val sourceDestination = NavigationDestinationFixtures.create(NavigationKeyFixtures.SimpleKey())
+        val destinationContext = NavigationContextFixtures.createDestinationContext(containerContext, sourceDestination)
+
+        container.execute(
+            destinationContext,
+            NavigationOperation.AggregateOperation(
+                NavigationOperation.Open(SyntheticTestKey.asInstance()),
+                NavigationOperation.Open(regularKey.asInstance()),
+            ),
+        )
+
+        assertEquals(
+            expected = listOf(targetKey, regularKey),
+            actual = container.backstack.map { it.key },
+            message = "Pure synthetic outcomes must be rewritten in place — backstack ordering was: ${container.backstack.map { it.key }}",
+        )
+    }
+
+    @Test
+    fun `Side-effect synthetic runs after the surrounding pass settles`() = runEnroTest {
+        // Assert that when the side-effect block runs, the container's
+        // backstack already reflects the other operations from the same
+        // processing pass — i.e. the side effect is deferred to
+        // afterExecution as advertised.
+        var observedBackstackAtSideEffect: List<NavigationKey>? = null
+        val regularKey = NavigationKeyFixtures.SimpleKey()
+        EnroTest.getCurrentNavigationController().addModule(
+            createNavigationModule {
+                destination<SyntheticTestKey>(
+                    syntheticDestination<SyntheticTestKey> {
+                        sideEffect {
+                            observedBackstackAtSideEffect = container.backstack.map { it.key }
+                        }
+                    }
+                )
+                destination<NavigationKeyFixtures.SimpleKey>(
+                    navigationDestination<NavigationKeyFixtures.SimpleKey> { Text("regular") }
+                )
+            }
+        )
+
+        val rootContext = NavigationContextFixtures.createRootContext()
+        val containerContext = NavigationContextFixtures.createContainerContext(rootContext)
+        val container = containerContext.container
+        container.setFilter(acceptAll())
+        container.addInterceptor(SyntheticDestination.interceptor)
+
+        val sourceDestination = NavigationDestinationFixtures.create(NavigationKeyFixtures.SimpleKey())
+        val destinationContext = NavigationContextFixtures.createDestinationContext(containerContext, sourceDestination)
+
+        container.execute(
+            destinationContext,
+            NavigationOperation.AggregateOperation(
+                NavigationOperation.Open(SyntheticTestKey.asInstance()),
+                NavigationOperation.Open(regularKey.asInstance()),
+            ),
+        )
+
+        assertEquals(
+            expected = listOf<NavigationKey>(regularKey),
+            actual = observedBackstackAtSideEffect,
+            message = "Side-effect block should run after the surrounding pass settled; observed: $observedBackstackAtSideEffect",
+        )
+    }
+
+    @Test
+    fun `Side-effect synthetic can rewrite the backstack via container execute`() = runEnroTest {
+        // Use sideEffect's container reference to perform a SetBackstack —
+        // the deferred-execution model that the framework prescribes for
+        // anything that can't be expressed as a pure outcome.
+        val newRootKey = NavigationKeyFixtures.SimpleKey()
+        val newTopKey = NavigationKeyFixtures.SimpleKey()
+        EnroTest.getCurrentNavigationController().addModule(
+            createNavigationModule {
+                destination<SyntheticTestKey>(
+                    syntheticDestination<SyntheticTestKey> {
+                        sideEffect {
+                            container.execute(
+                                context,
+                                NavigationOperation.SetBackstack(
+                                    currentBackstack = container.backstack,
+                                    targetBackstack = backstackOf(
+                                        newRootKey.asInstance(),
+                                        newTopKey.asInstance(),
+                                    ),
+                                ),
+                            )
+                        }
+                    }
+                )
+                destination<NavigationKeyFixtures.SimpleKey>(
+                    navigationDestination<NavigationKeyFixtures.SimpleKey> { Text("any") }
+                )
+            }
+        )
+
+        val container = openSynthetic(SyntheticTestKey.asInstance()).container
+
+        assertEquals(
+            expected = listOf(newRootKey, newTopKey),
+            actual = container.backstack.map { it.key },
+            message = "Side-effect's SetBackstack should have rewritten the backstack; was: ${container.backstack.map { it.key }}",
+        )
+    }
+
+    @Test
+    fun `Self-referential synthetic outcome trips the recursion guard`() = runEnroTest {
+        // A synthetic whose pure outcome opens itself would loop forever
+        // inside processOperations without a guard. We expect a clear
+        // IllegalStateException naming the offender.
+        EnroTest.getCurrentNavigationController().addModule(
+            createNavigationModule {
+                destination<SyntheticTestKey>(
+                    syntheticDestination<SyntheticTestKey> { open(SyntheticTestKey) }
+                )
+            }
+        )
+
+        val rootContext = NavigationContextFixtures.createRootContext()
+        val containerContext = NavigationContextFixtures.createContainerContext(rootContext)
+        val container = containerContext.container
+        container.setFilter(acceptAll())
+        container.addInterceptor(SyntheticDestination.interceptor)
+
+        val sourceDestination = NavigationDestinationFixtures.create(NavigationKeyFixtures.SimpleKey())
+        val destinationContext = NavigationContextFixtures.createDestinationContext(containerContext, sourceDestination)
+
+        val error = kotlin.runCatching {
+            container.execute(destinationContext, NavigationOperation.Open(SyntheticTestKey.asInstance()))
+        }.exceptionOrNull()
+
+        assertTrue(
+            actual = error is IllegalStateException,
+            message = "Expected IllegalStateException from the recursion guard; got: ${error?.let { it::class.simpleName }}",
+        )
+        assertTrue(
+            actual = error?.message?.contains("exceeded") == true,
+            message = "Recursion guard error should mention exceeding the iteration limit; was: ${error?.message}",
+        )
+    }
+
+    @Test
     fun `Synthetic completeFrom forwards result-channel routing to the chosen destination`() = runEnroTest {
         val forwarded = ResultBearingSyntheticTestKey()
         EnroTest.getCurrentNavigationController().addModule(

--- a/recipes/src/commonMain/kotlin/dev/enro/recipes/synthetic/ExternalUrlSynthetic.kt
+++ b/recipes/src/commonMain/kotlin/dev/enro/recipes/synthetic/ExternalUrlSynthetic.kt
@@ -3,20 +3,21 @@
  *
  * Demonstrates the side-effect-bridge pattern: a `NavigationKey` whose
  * destination doesn't render any UI and doesn't change the Enro navigation
- * state. The synthetic block runs imperative work and then falls through;
- * the dispatcher treats fall-through as a silent close (no result-channel
- * callback fires).
+ * state. The synthetic's outcome is `sideEffect { ... }`, which runs the
+ * body deferred — after the surrounding navigation pass has settled —
+ * with platform context and the container reference available. The
+ * synthetic itself is treated as silently closed; no result-channel
+ * callback fires for the caller.
  *
- * In a real app this synthetic would invoke a platform-specific API:
- *  - Android: `activity.startActivity(Intent(ACTION_VIEW, Uri.parse(url)))`
+ * In a real app the side-effect body would invoke a platform-specific API:
+ *  - Android: `context.findActivity().startActivity(Intent(ACTION_VIEW, Uri.parse(url)))`
  *    or Chrome Custom Tabs via androidx.browser
  *  - Desktop:  `java.awt.Desktop.getDesktop().browse(URI(url))`
  *  - Web:     `window.open(url, "_blank")`
  *
  * Cross-platform launch from common code is out of scope for the recipe
- * itself, so the synthetic just records each requested URL in an in-memory
- * log that the recipe screen displays. The shape of the synthetic is what
- * matters here — the block runs, no Enro navigation happens.
+ * itself, so the side effect just records each requested URL in an
+ * in-memory log that the recipe screen displays.
  */
 package dev.enro.recipes.synthetic
 
@@ -52,13 +53,15 @@ private val openedUrls = mutableStateListOf<String>()
 
 @NavigationDestination(OpenExternalUrl::class)
 val openExternalUrl = syntheticDestination<OpenExternalUrl> {
-    // In a real app: launch CCT on Android, Desktop.browse on desktop,
-    // window.open on web. See the file header for snippets.
-    openedUrls.add(key.url)
-    // No outcome method is called — the block falls through. The dispatcher
-    // treats that as a silent close: no result-channel callback fires for
-    // the caller, the synthetic instance never lands on any backstack, and
-    // the Enro state is unchanged.
+    sideEffect {
+        // In a real app: context.findActivity() on Android then start the
+        // CCT intent; Desktop.browse() on desktop; window.open on web.
+        // See the file header for snippets.
+        openedUrls.add(key.url)
+        // The side effect dispatched, so the synthetic is silently closed
+        // — no result-channel callback fires, the synthetic instance
+        // never lands on any backstack, and the Enro state is unchanged.
+    }
 }
 
 @Composable


### PR DESCRIPTION
## Summary

Restructures how synthetic destinations dispatch their outcomes. Outcomes now split into two clearly-distinct kinds:

- **Pure outcomes** — `open`, `close`, `closeSilently`, `complete`, `completeFrom`. The dispatcher rewrites the original `Open(synthetic)` into the equivalent operation inside its interceptor, so the rewrite happens during the *same* `processOperations` pass. Ordering is preserved when synthetics appear in an initial backstack alongside other entries.
- **Side-effect outcome** — `sideEffect { ... }`. The block runs deferred via `NavigationOperation.SideEffect` in `afterExecution`, with a new `SyntheticSideEffectScope<K>` receiver carrying `context`, `container`, `instance`, and `key`. Use this when you need platform handles, the container reference, or imperative work that doesn't fit a single navigation operation. The synthetic is treated as silently closed once the side effect dispatches.

The old `executeSynthetic` companion method goes away — it was the deferred-execution bridge that the in-place rewrite replaces.

## Why

The previous model used `NavigationOperation.SideEffect` for *every* synthetic outcome. The block ran in `afterExecution`; its outcome operations were dispatched via a nested `container.execute(...)` call. That worked but had two real problems:

1. **Ordering bug for initial backstacks.** `[SyntheticThatOpensA, B]` settled as `[B]`, and then `A` was appended by the synthetic's nested `execute`, giving `[B, A]` instead of the expected `[A, B]`.
2. **No way to express "rewrite the backstack" as an outcome.** Anything beyond the focused outcome set required reaching for `context.controller.execute(...)` from inside the block, which ran while the execute mutex was held → deadlock risk.

The in-place rewrite fixes (1) by construction — the synthetic's outcome operation takes the synthetic's slot in the `toProcess` queue and flows through the same interceptor pipeline. For (2), the `sideEffect` outcome gives users a deliberate, deferred place to do that kind of work, with full container access.

The split also makes the model honest about what's pure (a deterministic substitution of one operation for another) and what's a side effect (imperative work touching state outside the operation pipeline). Pure outcomes are safe to compose; side effects are explicitly stamped as "this is doing something the pipeline can't represent."

## Recursion guard

`processOperations` now caps its `toProcess` loop at 256 iterations and throws a clear `IllegalStateException` naming the most recent operation if exceeded. Catches synthetic infinite-loop patterns (A opens A, mutual recursion A→B→A, etc.) instead of hanging the controller. The cap is well above what any legitimate pass needs.

## What's NOT in this PR

- **`navigationContext` and `instruction` migration shims on `SyntheticDestinationScope`.** Still present as `@Deprecated(WARNING)`. The compat library needs to support v2 migration for big projects; revisit removal in 3.1.x.
- **Initial-backstack-runs-interceptors as a separate feature.** The in-place rewrite incidentally fixes the original "synthetics in initial backstacks crash at render time" problem for the common case (single-entry synthetic) and the multi-entry ordering case. A fuller "every initial backstack goes through interceptors uniformly" change can land later if needed; deferred since this PR makes it unnecessary for the synthetic case.

## Shape of the new API

```kotlin
// Pure outcome — runs in place during processOperations
syntheticDestination<EditProfile> {
    if (featureFlags.useNewProfileUi) completeFrom(EditProfileV2)
    else completeFrom(EditProfileLegacy)
}

// Side-effect outcome — runs deferred with context + container access
syntheticDestination<OpenExternalUrl> {
    sideEffect {
        val activity = context.findActivity()
        activity.startActivity(Intent(ACTION_VIEW, Uri.parse(key.url)))
    }
}

// Side-effect that rewrites the backstack
syntheticDestination<DeepLinkResolver> {
    sideEffect {
        val resolved = context.controller.getNavigationKeyFromPath(key.url)
            ?: return@sideEffect
        container.execute(
            context = context,
            operation = NavigationOperation.SetBackstack(
                currentBackstack = container.backstack,
                targetBackstack = backstackOf(Home.asInstance(), resolved.asInstance()),
            ),
        )
    }
}
```

## Test plan

- [ ] `./gradlew :enro-runtime:desktopTest` — full suite green; 15/15 `SyntheticDestinationTests` pass (11 existing unchanged + 4 new).
- [ ] `./gradlew :recipes:compileKotlinDesktop :recipes:compileKotlinWasmJs` — recipes still build, including the updated `ExternalUrlSynthetic` recipe.
- [ ] `./gradlew :enro-compat:compileDebugKotlinAndroid` — compat module compiles against the new dispatcher (existing `sendResult`/`forwardResult` shims still delegate correctly).
- [ ] New test cases manually inspectable: `SyntheticDestinationTests` covers (a) pure-outcome ordering in an AggregateOperation, (b) side-effect block sees the post-rewrite backstack, (c) side-effect can call `container.execute(SetBackstack(...))`, (d) the recursion guard trips for a self-referential synthetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)