### PR TITLE
enro-test: synthetic destination testing + ergonomic helpers

### DIFF
--- a/docs/ghpages/docs/advanced/synthetic-destinations.md
+++ b/docs/ghpages/docs/advanced/synthetic-destinations.md
@@ -263,6 +263,95 @@ val deepLinkResolver = syntheticDestination<DeepLinkResolver> {
 }
 ```
 
+## Testing synthetic destinations
+
+enro-test provides `testSyntheticDestination(...)` for unit-testing
+synthetic logic without going through a real container or interceptor
+pipeline. It runs the synthetic's block in a sandbox scope and returns
+a [`SyntheticOutcome`][synthetic-outcome] describing what the block
+decided.
+
+Two entry points cover the two common test shapes:
+
+### Registered path — via the installed controller
+
+Use this when the synthetic is registered through a `NavigationModule` on
+your component, as it would be in production:
+
+```kotlin
+@Test
+fun `auth gate forwards to protected screen when logged in`() = runEnroTest {
+    MyComponent.installNavigationController(this)
+    isLoggedIn = true  // app-state setup
+
+    val outcome = testSyntheticDestination(RequireProtectedFeature)
+
+    outcome.assertOpens<AuthGateProtectedFeature>()
+}
+```
+
+### Direct path — provider passed in
+
+Use this for pure unit tests that don't need a controller installed. Pass
+the `NavigationDestinationProvider` value directly:
+
+```kotlin
+val authGate = syntheticDestination<RequireProtectedFeature> {
+    if (sessionRepository.isLoggedIn) open(AuthGateProtectedFeature)
+    else open(AuthGateLogin)
+}
+
+@Test
+fun `auth gate redirects to login when logged out`() {
+    sessionRepository.signOut()
+
+    val outcome = testSyntheticDestination(RequireProtectedFeature, authGate)
+
+    outcome.assertOpens<AuthGateLogin>()
+}
+```
+
+### Assertion helpers
+
+| Helper | Asserts |
+|---|---|
+| `assertOpens<T>(predicate?)` | Outcome is `Open` of a key of type `T`, optionally matching `predicate`. Returns the typed key. |
+| `assertCompletesFrom<T>(predicate?)` | Outcome is `CompleteFrom` of a key of type `T`. Returns the typed key. |
+| `assertCloses(silent?)` | Outcome is `Close`, optionally matching the `silent` flag. |
+| `assertCompletes(expectedResult)` | Outcome is `Complete` with the given payload. Pass `null` for non-result synthetics. |
+| `assertSideEffect()` | Outcome is `SideEffect`. Returns the side-effect so you can run it (see below). |
+
+### Executing side-effect outcomes
+
+A `SideEffect` outcome carries the block but doesn't auto-invoke it —
+the test gets to decide whether to run it, and with what scope:
+
+```kotlin
+@Test
+fun `external URL synthetic runs the launch side effect`() {
+    val outcome = testSyntheticDestination(OpenExternalUrl("https://enro.dev"), openExternalUrl)
+    outcome.assertSideEffect().runWith()
+    // …assert on whatever the side effect produced (mock state, captured intents, etc.)
+}
+```
+
+`runWith()` with no arguments uses default fixture context and container
+— enough for most tests. Pass explicit `context: NavigationContext` and
+`container: NavigationContainer` arguments when the side effect's
+behaviour depends on either.
+
+### What you DON'T get from the test helper
+
+`testSyntheticDestination` runs the block in isolation — it doesn't
+dispatch operations against any container's backstack. So if your
+synthetic calls `open(Other)`, the test sees a `SyntheticOutcome.Open(Other)`
+but `Other` doesn't actually land in any backstack. For end-to-end
+backstack assertions, fall back to the container fixtures and execute
+the operation through `container.execute(...)` as the
+`SyntheticDestinationTests` in enro-runtime do.
+
+[synthetic-outcome]: https://github.com/isaac-udy/Enro/blob/main/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticOutcome.kt
+
 ## See also
 
 - [Returning results](results.md) — the result contract that `complete`

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticDestination.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticDestination.kt
@@ -4,6 +4,8 @@ import dev.enro.EnroController
 import dev.enro.NavigationContext
 import dev.enro.NavigationKey
 import dev.enro.NavigationOperation
+import dev.enro.annotations.AdvancedEnroApi
+import dev.enro.asInstance
 import dev.enro.context.ContainerContext
 import dev.enro.interceptor.NavigationInterceptor
 import dev.enro.ui.NavigationDestination
@@ -116,4 +118,70 @@ public fun isSyntheticDestination(
         ?.peekMetadata(instance)
         ?.contains(SyntheticDestination.SyntheticDestinationKey)
         ?: false
+}
+
+/**
+ * Runs the synthetic block bound to this [NavigationDestinationProvider]
+ * with a fresh [SyntheticDestinationScope] and returns the [SyntheticOutcome]
+ * the block decided on. Returns `null` if this provider isn't a synthetic
+ * destination at all.
+ *
+ * Primarily intended for unit-testing synthetic destinations without going
+ * through the navigation container's interceptor pipeline. The
+ * `testSyntheticDestination` helpers in enro-test wrap this with default
+ * context fixtures and assertion helpers.
+ */
+/**
+ * Looks up the synthetic destination bound to [key] on the controller's
+ * registered bindings and runs it via [NavigationDestinationProvider.peekSyntheticOutcome].
+ * Returns `null` if no binding exists for [key], or the bound destination
+ * isn't a synthetic.
+ *
+ * Used by enro-test's `testSyntheticDestination` helper to find a synthetic
+ * registered on the installed controller without exposing the controller's
+ * binding repository as public API.
+ */
+@AdvancedEnroApi
+public fun <K : NavigationKey> EnroController.peekSyntheticOutcome(
+    key: K,
+    context: NavigationContext,
+): SyntheticOutcome? {
+    val instance = key.asInstance()
+    val binding = runCatching { bindings.bindingFor(instance) }.getOrNull() ?: return null
+    @Suppress("UNCHECKED_CAST")
+    val provider = binding.provider as NavigationDestinationProvider<K>
+    return provider.peekSyntheticOutcome(context, instance)
+}
+
+@AdvancedEnroApi
+public fun <K : NavigationKey> NavigationDestinationProvider<K>.peekSyntheticOutcome(
+    context: NavigationContext,
+    instance: NavigationKey.Instance<K>,
+): SyntheticOutcome? {
+    val syntheticDestination = peekMetadata(instance)[SyntheticDestination.SyntheticDestinationKey]
+        ?: return null
+    @Suppress("UNCHECKED_CAST")
+    val synthetic = syntheticDestination as SyntheticDestination<K>
+    val scope = SyntheticDestinationScope(
+        context = context,
+        instance = instance,
+    )
+    val thrown = try {
+        synthetic.block(scope)
+        null
+    } catch (outcome: SyntheticDestinationOutcome) {
+        outcome
+    }
+    val effective = thrown ?: scope.finalizeAsSilentCloseIfNoOutcome()
+
+    return when (effective) {
+        is SyntheticDestinationOutcome.Open -> SyntheticOutcome.Open(effective.target)
+        is SyntheticDestinationOutcome.Close -> SyntheticOutcome.Close(effective.silent)
+        is SyntheticDestinationOutcome.Complete -> SyntheticOutcome.Complete(effective.result)
+        is SyntheticDestinationOutcome.CompleteFrom -> SyntheticOutcome.CompleteFrom(effective.target)
+        is SyntheticDestinationOutcome.SideEffect -> SyntheticOutcome.SideEffect(
+            instance = instance,
+            block = effective.block,
+        )
+    }
 }

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticOutcome.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/ui/destinations/SyntheticOutcome.kt
@@ -1,0 +1,65 @@
+package dev.enro.ui.destinations
+
+import dev.enro.NavigationContainer
+import dev.enro.NavigationContext
+import dev.enro.NavigationKey
+
+/**
+ * The decision a synthetic destination's block made when it ran. Returned by
+ * [NavigationDestinationProvider.peekSyntheticOutcome] and consumed by
+ * `testSyntheticDestination` in enro-test for unit-testing synthetic logic
+ * without going through the navigation container's interceptor pipeline.
+ *
+ * Mirrors the internal `SyntheticDestinationOutcome` sealed class but is a
+ * plain value type — not a thrown sentinel — so it can be inspected,
+ * pattern-matched and asserted against.
+ */
+public sealed class SyntheticOutcome {
+
+    /** The synthetic's block called `open(...)` — the dispatcher would rewrite the synthetic's `Open` to `Open(target)`. */
+    public data class Open(public val instance: NavigationKey.Instance<*>) : SyntheticOutcome() {
+        public val key: NavigationKey get() = instance.key
+    }
+
+    /** The synthetic's block called `close()` or `closeSilently()`. */
+    public data class Close(public val silent: Boolean) : SyntheticOutcome()
+
+    /** The synthetic's block called `complete(...)`. `result` is the typed payload (or `null` for non-result keys). */
+    public data class Complete(public val result: Any?) : SyntheticOutcome()
+
+    /** The synthetic's block called `completeFrom(...)` — the chosen key's eventual completion would route back to the original caller. */
+    public data class CompleteFrom(public val instance: NavigationKey.Instance<*>) : SyntheticOutcome() {
+        public val key: NavigationKey get() = instance.key
+    }
+
+    /**
+     * The synthetic's block called `sideEffect { ... }`. The block is not
+     * automatically invoked when the outcome is produced — call [runWith]
+     * to execute it. Useful in tests that want to inspect *what* side
+     * effect the synthetic chose without running it, or that want to
+     * provide a controlled scope (e.g. a mock context) for the side effect
+     * to operate against.
+     */
+    public class SideEffect @PublishedApi internal constructor(
+        public val instance: NavigationKey.Instance<*>,
+        @PublishedApi
+        internal val block: SyntheticSideEffectScope<NavigationKey>.() -> Unit,
+    ) : SyntheticOutcome() {
+        /**
+         * Executes the side-effect block with the given [context] and
+         * [container] as the scope.
+         */
+        public fun runWith(
+            context: NavigationContext,
+            container: NavigationContainer,
+        ) {
+            @Suppress("UNCHECKED_CAST")
+            val scope = SyntheticSideEffectScope(
+                context = context,
+                container = container,
+                instance = instance as NavigationKey.Instance<NavigationKey>,
+            )
+            scope.block()
+        }
+    }
+}

--- a/enro-runtime/src/commonTest/kotlin/dev/enro/EnroTestHelpersTests.kt
+++ b/enro-runtime/src/commonTest/kotlin/dev/enro/EnroTestHelpersTests.kt
@@ -1,0 +1,230 @@
+@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+
+package dev.enro
+
+import dev.enro.path.NavigationPathBinding
+import dev.enro.path.createPathBinding
+import dev.enro.test.EnroTest
+import dev.enro.test.EnroTestAssertionException
+import dev.enro.test.NavigationKeyFixtures
+import dev.enro.test.assertBackstackContains
+import dev.enro.test.assertBackstackDoesNotContain
+import dev.enro.test.assertBackstackEmpty
+import dev.enro.test.assertBackstackKeys
+import dev.enro.test.assertBackstackSize
+import dev.enro.test.assertOperationSequence
+import dev.enro.test.assertPathDoesNotResolve
+import dev.enro.test.assertPathFor
+import dev.enro.test.assertPathResolvesTo
+import dev.enro.test.createTestNavigationHandle
+import dev.enro.test.fixtures.NavigationContainerFixtures
+import dev.enro.test.installNavigationModule
+import dev.enro.test.installPathBindings
+import dev.enro.test.lastOperation
+import dev.enro.test.lastOperationOfType
+import dev.enro.test.runEnroTest
+import kotlinx.serialization.Serializable
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the enro-test ergonomic helpers shipped alongside the synthetic
+ * destination testing API. Covers backstack assertions, the install* module
+ * shortcuts, path-resolution assertions, and TestNavigationHandle operation
+ * history helpers.
+ */
+class EnroTestHelpersTests {
+
+    // ---- Backstack assertions ----
+
+    @Test
+    fun `assertBackstackSize matches an empty backstack`() = runEnroTest {
+        val container = NavigationContainerFixtures.create()
+        container.container.assertBackstackSize(0)
+    }
+
+    @Test
+    fun `assertBackstackSize fails with a helpful message`() = runEnroTest {
+        val container = NavigationContainerFixtures.create()
+
+        val error = assertFailsWith<EnroTestAssertionException> {
+            container.container.assertBackstackSize(3)
+        }
+        assertTrue(error.message?.contains("Expected backstack to have 3 entries") == true)
+    }
+
+    @Test
+    fun `assertBackstackKeys matches exact key sequence`() = runEnroTest {
+        val key1 = NavigationKeyFixtures.SimpleKey()
+        val key2 = NavigationKeyFixtures.SimpleKey()
+        val container = NavigationContainerFixtures.create(
+            backstack = backstackOf(key1.asInstance(), key2.asInstance()),
+        )
+        container.container.assertBackstackKeys(key1, key2)
+    }
+
+    @Test
+    fun `assertBackstackContains finds a matching key by type`() = runEnroTest {
+        val key = HelpersResultKey()
+        val container = NavigationContainerFixtures.create(
+            backstack = backstackOf(NavigationKeyFixtures.SimpleKey().asInstance(), key.asInstance()),
+        )
+        val found = container.container.assertBackstackContains<HelpersResultKey>()
+        assertEquals(key, found.key)
+    }
+
+    @Test
+    fun `assertBackstackDoesNotContain succeeds when key type is absent`() = runEnroTest {
+        val container = NavigationContainerFixtures.create(
+            backstack = backstackOf(NavigationKeyFixtures.SimpleKey().asInstance()),
+        )
+        container.container.assertBackstackDoesNotContain<HelpersResultKey>()
+    }
+
+    @Test
+    fun `assertBackstackEmpty passes for empty backstack and fails for non-empty`() = runEnroTest {
+        val empty = NavigationContainerFixtures.create()
+        empty.container.assertBackstackEmpty()
+
+        val nonEmpty = NavigationContainerFixtures.create(
+            backstack = backstackOf(NavigationKeyFixtures.SimpleKey().asInstance()),
+        )
+        assertFailsWith<EnroTestAssertionException> {
+            nonEmpty.container.assertBackstackEmpty()
+        }
+    }
+
+    // ---- installNavigationModule / installPathBindings ----
+
+    @Test
+    fun `installPathBindings registers bindings on the test controller`() = runEnroTest {
+        val binding = NavigationPathBinding.createPathBinding<String, HelpersPathKey>(
+            pattern = "items/{id}",
+            propertyOne = HelpersPathKey::id,
+            constructor = ::HelpersPathKey,
+        )
+        installPathBindings(binding)
+
+        EnroTest.getCurrentNavigationController()
+            .assertPathResolvesTo<HelpersPathKey>("/items/abc")
+    }
+
+    // ---- Path resolution assertions ----
+
+    @Test
+    fun `assertPathResolvesTo returns the typed key matching predicate`() = runEnroTest {
+        val binding = NavigationPathBinding.createPathBinding<String, HelpersPathKey>(
+            pattern = "items/{id}",
+            propertyOne = HelpersPathKey::id,
+            constructor = ::HelpersPathKey,
+        )
+        installPathBindings(binding)
+        val controller = EnroTest.getCurrentNavigationController()
+
+        val key = controller.assertPathResolvesTo<HelpersPathKey>("/items/xyz") { it.id == "xyz" }
+
+        assertEquals("xyz", key.id)
+    }
+
+    @Test
+    fun `assertPathDoesNotResolve passes when no binding matches`() = runEnroTest {
+        val controller = EnroTest.getCurrentNavigationController()
+        controller.assertPathDoesNotResolve("/items/never-resolved")
+    }
+
+    @Test
+    fun `assertPathFor checks the reverse-direction serialisation`() = runEnroTest {
+        installPathBindings(
+            NavigationPathBinding.createPathBinding<String, HelpersPathKey>(
+                pattern = "items/{id}",
+                propertyOne = HelpersPathKey::id,
+                constructor = ::HelpersPathKey,
+            )
+        )
+        val controller = EnroTest.getCurrentNavigationController()
+
+        controller.assertPathFor(HelpersPathKey("zzz"), expectedPath = "/items/zzz")
+    }
+
+    @Test
+    fun `assertPathResolvesTo fails with a helpful message for wrong type`() = runEnroTest {
+        installPathBindings(
+            NavigationPathBinding.createPathBinding<String, HelpersPathKey>(
+                pattern = "items/{id}",
+                propertyOne = HelpersPathKey::id,
+                constructor = ::HelpersPathKey,
+            )
+        )
+        val controller = EnroTest.getCurrentNavigationController()
+
+        val error = assertFailsWith<EnroTestAssertionException> {
+            controller.assertPathResolvesTo<NavigationKeyFixtures.SimpleKey>("/items/abc")
+        }
+        assertTrue(error.message?.contains("resolved to") == true)
+    }
+
+    // ---- Operation history fluency ----
+
+    @Test
+    fun `lastOperation returns the most recent operation`() = runEnroTest {
+        val handle = createTestNavigationHandle(HelpersResultKey())
+        handle.execute(NavigationOperation.Open(NavigationKeyFixtures.SimpleKey().asInstance()))
+        handle.execute(NavigationOperation.Close(handle.instance))
+
+        val last = handle.lastOperation()
+        assertTrue(last is NavigationOperation.Close<*>)
+    }
+
+    @Test
+    fun `lastOperationOfType filters by operation subtype`() = runEnroTest {
+        val handle = createTestNavigationHandle(HelpersResultKey())
+        handle.execute(NavigationOperation.Open(NavigationKeyFixtures.SimpleKey().asInstance()))
+        handle.execute(NavigationOperation.Close(handle.instance))
+
+        val lastOpen = handle.lastOperationOfType<NavigationOperation.Open<*>>()
+        assertTrue(lastOpen.instance.key is NavigationKeyFixtures.SimpleKey)
+    }
+
+    @Test
+    fun `assertOperationSequence enforces type ordering`() = runEnroTest {
+        val handle = createTestNavigationHandle(HelpersResultKey())
+        handle.execute(NavigationOperation.Open(NavigationKeyFixtures.SimpleKey().asInstance()))
+        handle.execute(NavigationOperation.Close(handle.instance))
+
+        handle.assertOperationSequence(
+            NavigationOperation.Open::class,
+            NavigationOperation.Close::class,
+        )
+    }
+
+    @Test
+    fun `assertOperationSequence fails with mismatched sequence`() = runEnroTest {
+        val handle = createTestNavigationHandle(HelpersResultKey())
+        handle.execute(NavigationOperation.Open(NavigationKeyFixtures.SimpleKey().asInstance()))
+
+        val error = assertFailsWith<EnroTestAssertionException> {
+            handle.assertOperationSequence(
+                NavigationOperation.Close::class,
+                NavigationOperation.Open::class,
+            )
+        }
+        assertTrue(error.message?.contains("Expected operation sequence") == true)
+    }
+
+    @Test
+    fun `lastOperation fails when no operations were executed`() = runEnroTest {
+        val handle = createTestNavigationHandle(HelpersResultKey())
+
+        assertFailsWith<EnroTestAssertionException> {
+            handle.lastOperation()
+        }
+    }
+}
+
+@Serializable
+data class HelpersPathKey(val id: String) : NavigationKey
+
+@Serializable
+class HelpersResultKey : NavigationKey.WithResult<String>

--- a/enro-runtime/src/commonTest/kotlin/dev/enro/SyntheticDestinationTesterTests.kt
+++ b/enro-runtime/src/commonTest/kotlin/dev/enro/SyntheticDestinationTesterTests.kt
@@ -35,7 +35,7 @@ class SyntheticDestinationTesterTests {
     // ---- Registered-path tests ----
 
     @Test
-    fun `testSyntheticDestination(key) finds the synthetic via controller bindings`() = runEnroTest {
+    fun `testSyntheticDestination by key finds the synthetic via controller bindings`() = runEnroTest {
         EnroTest.getCurrentNavigationController().addModule(
             createNavigationModule {
                 destination<SyntheticTesterOpenKey>(
@@ -121,7 +121,7 @@ class SyntheticDestinationTesterTests {
     }
 
     @Test
-    fun `testSyntheticDestination(key) throws a clear error when key isn't bound`() = runEnroTest {
+    fun `testSyntheticDestination by key throws a clear error when key isn't bound`() = runEnroTest {
         EnroTest.getCurrentNavigationController().addModule(createNavigationModule {})
 
         val error = assertFailsWith<IllegalStateException> {
@@ -134,7 +134,7 @@ class SyntheticDestinationTesterTests {
     }
 
     @Test
-    fun `testSyntheticDestination(key) throws when the bound destination is not a synthetic`() = runEnroTest {
+    fun `testSyntheticDestination by key throws when the bound destination is not a synthetic`() = runEnroTest {
         EnroTest.getCurrentNavigationController().addModule(
             createNavigationModule {
                 destination<SyntheticTesterOpenKey>(
@@ -155,7 +155,7 @@ class SyntheticDestinationTesterTests {
     // ---- Direct-path (no controller install) tests ----
 
     @Test
-    fun `testSyntheticDestination(key, provider) works without installing the synthetic on the controller`() = runEnroTest {
+    fun `testSyntheticDestination by key and provider works without installing the synthetic on the controller`() = runEnroTest {
         // No addModule call — the synthetic provider is passed directly.
         val provider = syntheticDestination<SyntheticTesterOpenKey> { open(SyntheticTesterTargetKey()) }
 

--- a/enro-runtime/src/commonTest/kotlin/dev/enro/SyntheticDestinationTesterTests.kt
+++ b/enro-runtime/src/commonTest/kotlin/dev/enro/SyntheticDestinationTesterTests.kt
@@ -1,0 +1,235 @@
+@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+
+package dev.enro
+
+import androidx.compose.material3.Text
+import dev.enro.controller.createNavigationModule
+import dev.enro.test.EnroTest
+import dev.enro.test.assertCloses
+import dev.enro.test.assertCompletes
+import dev.enro.test.assertCompletesFrom
+import dev.enro.test.assertOpens
+import dev.enro.test.assertSideEffect
+import dev.enro.test.runEnroTest
+import dev.enro.test.runWith
+import dev.enro.test.testSyntheticDestination
+import dev.enro.ui.destinations.complete
+import dev.enro.ui.destinations.completeFrom
+import dev.enro.ui.destinations.syntheticDestination
+import dev.enro.ui.navigationDestination
+import kotlinx.serialization.Serializable
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the `testSyntheticDestination` helpers in enro-test. Covers each
+ * outcome path through both entry points: looking up the synthetic via the
+ * controller's bindings (the "registered" path), and providing the
+ * NavigationDestinationProvider directly (the "direct" path that doesn't
+ * need a controller install).
+ */
+class SyntheticDestinationTesterTests {
+
+    // ---- Registered-path tests ----
+
+    @Test
+    fun `testSyntheticDestination(key) finds the synthetic via controller bindings`() = runEnroTest {
+        EnroTest.getCurrentNavigationController().addModule(
+            createNavigationModule {
+                destination<SyntheticTesterOpenKey>(
+                    syntheticDestination<SyntheticTesterOpenKey> { open(SyntheticTesterTargetKey()) }
+                )
+            }
+        )
+
+        val outcome = testSyntheticDestination(SyntheticTesterOpenKey)
+
+        outcome.assertOpens<SyntheticTesterTargetKey>()
+    }
+
+    @Test
+    fun `Registered close outcome is reported as Close`() = runEnroTest {
+        EnroTest.getCurrentNavigationController().addModule(
+            createNavigationModule {
+                destination<SyntheticTesterOpenKey>(
+                    syntheticDestination<SyntheticTesterOpenKey> { close() }
+                )
+            }
+        )
+
+        testSyntheticDestination(SyntheticTesterOpenKey).assertCloses(silent = false)
+    }
+
+    @Test
+    fun `Registered closeSilently outcome is reported as Close with silent=true`() = runEnroTest {
+        EnroTest.getCurrentNavigationController().addModule(
+            createNavigationModule {
+                destination<SyntheticTesterOpenKey>(
+                    syntheticDestination<SyntheticTesterOpenKey> { closeSilently() }
+                )
+            }
+        )
+
+        testSyntheticDestination(SyntheticTesterOpenKey).assertCloses(silent = true)
+    }
+
+    @Test
+    fun `Registered complete with result is reported as Complete with the payload`() = runEnroTest {
+        EnroTest.getCurrentNavigationController().addModule(
+            createNavigationModule {
+                destination<SyntheticTesterResultKey>(
+                    syntheticDestination<SyntheticTesterResultKey> { complete("hello") }
+                )
+            }
+        )
+
+        testSyntheticDestination(SyntheticTesterResultKey()).assertCompletes(expectedResult = "hello")
+    }
+
+    @Test
+    fun `Registered completeFrom is reported as CompleteFrom of the forwarded key`() = runEnroTest {
+        EnroTest.getCurrentNavigationController().addModule(
+            createNavigationModule {
+                destination<SyntheticTesterResultKey>(
+                    navigationDestination<SyntheticTesterResultKey> { Text("forwarded") }
+                )
+                destination<SyntheticTesterForwarderKey>(
+                    syntheticDestination<SyntheticTesterForwarderKey> { completeFrom(SyntheticTesterResultKey()) }
+                )
+            }
+        )
+
+        testSyntheticDestination(SyntheticTesterForwarderKey())
+            .assertCompletesFrom<SyntheticTesterResultKey>()
+    }
+
+    @Test
+    fun `Registered fall-through is reported as a silent close`() = runEnroTest {
+        EnroTest.getCurrentNavigationController().addModule(
+            createNavigationModule {
+                destination<SyntheticTesterOpenKey>(
+                    syntheticDestination<SyntheticTesterOpenKey> {
+                        // no outcome method
+                    }
+                )
+            }
+        )
+
+        testSyntheticDestination(SyntheticTesterOpenKey).assertCloses(silent = true)
+    }
+
+    @Test
+    fun `testSyntheticDestination(key) throws a clear error when key isn't bound`() = runEnroTest {
+        EnroTest.getCurrentNavigationController().addModule(createNavigationModule {})
+
+        val error = assertFailsWith<IllegalStateException> {
+            testSyntheticDestination(SyntheticTesterOpenKey)
+        }
+        assertTrue(
+            actual = error.message?.contains("not bound to a synthetic destination") == true,
+            message = "Error should explain the synthetic isn't bound; was: ${error.message}",
+        )
+    }
+
+    @Test
+    fun `testSyntheticDestination(key) throws when the bound destination is not a synthetic`() = runEnroTest {
+        EnroTest.getCurrentNavigationController().addModule(
+            createNavigationModule {
+                destination<SyntheticTesterOpenKey>(
+                    navigationDestination<SyntheticTesterOpenKey> { Text("ordinary destination") }
+                )
+            }
+        )
+
+        val error = assertFailsWith<IllegalStateException> {
+            testSyntheticDestination(SyntheticTesterOpenKey)
+        }
+        assertTrue(
+            actual = error.message?.contains("not bound to a synthetic destination") == true,
+            message = "Error should explain that the binding isn't a synthetic; was: ${error.message}",
+        )
+    }
+
+    // ---- Direct-path (no controller install) tests ----
+
+    @Test
+    fun `testSyntheticDestination(key, provider) works without installing the synthetic on the controller`() = runEnroTest {
+        // No addModule call — the synthetic provider is passed directly.
+        val provider = syntheticDestination<SyntheticTesterOpenKey> { open(SyntheticTesterTargetKey()) }
+
+        val outcome = testSyntheticDestination(SyntheticTesterOpenKey, provider)
+
+        outcome.assertOpens<SyntheticTesterTargetKey>()
+    }
+
+    @Test
+    fun `Direct-path supports each outcome shape`() = runEnroTest {
+        val openProvider = syntheticDestination<SyntheticTesterOpenKey> { open(SyntheticTesterTargetKey()) }
+        val closeProvider = syntheticDestination<SyntheticTesterOpenKey> { close() }
+        val completeProvider = syntheticDestination<SyntheticTesterResultKey> { complete("ok") }
+        val sideEffectProvider = syntheticDestination<SyntheticTesterOpenKey> {
+            sideEffect { /* no-op */ }
+        }
+
+        testSyntheticDestination(SyntheticTesterOpenKey, openProvider).assertOpens<SyntheticTesterTargetKey>()
+        testSyntheticDestination(SyntheticTesterOpenKey, closeProvider).assertCloses(silent = false)
+        testSyntheticDestination(SyntheticTesterResultKey(), completeProvider).assertCompletes("ok")
+        testSyntheticDestination(SyntheticTesterOpenKey, sideEffectProvider).assertSideEffect()
+    }
+
+    @Test
+    fun `Direct-path throws when the provider isn't a synthetic`() = runEnroTest {
+        val notSynthetic = navigationDestination<SyntheticTesterOpenKey> { Text("ordinary") }
+
+        val error = assertFailsWith<IllegalStateException> {
+            testSyntheticDestination(SyntheticTesterOpenKey, notSynthetic)
+        }
+        assertTrue(
+            actual = error.message?.contains("not a synthetic destination") == true,
+            message = "Error should explain the provider isn't synthetic; was: ${error.message}",
+        )
+    }
+
+    // ---- Side-effect tests ----
+
+    @Test
+    fun `SideEffect runWith default fixtures executes the block`() = runEnroTest {
+        var ran = false
+        val provider = syntheticDestination<SyntheticTesterOpenKey> {
+            sideEffect { ran = true }
+        }
+
+        val outcome = testSyntheticDestination(SyntheticTesterOpenKey, provider)
+
+        outcome.assertSideEffect().runWith()
+        assertTrue(ran, "Side-effect block should have run")
+    }
+
+    @Test
+    fun `SideEffect block sees the instance and key from the synthetic`() = runEnroTest {
+        var capturedKey: NavigationKey? = null
+        val provider = syntheticDestination<SyntheticTesterOpenKey> {
+            sideEffect { capturedKey = key }
+        }
+
+        testSyntheticDestination(SyntheticTesterOpenKey, provider)
+            .assertSideEffect()
+            .runWith()
+
+        assertEquals(SyntheticTesterOpenKey, capturedKey)
+    }
+}
+
+@Serializable
+data object SyntheticTesterOpenKey : NavigationKey
+
+@Serializable
+data class SyntheticTesterTargetKey(val id: String = "target") : NavigationKey
+
+@Serializable
+class SyntheticTesterResultKey : NavigationKey.WithResult<String>
+
+@Serializable
+class SyntheticTesterForwarderKey : NavigationKey.WithResult<String>

--- a/enro-test/src/commonMain/kotlin/dev/enro/test/NavigationContainer.assertBackstack.kt
+++ b/enro-test/src/commonMain/kotlin/dev/enro/test/NavigationContainer.assertBackstack.kt
@@ -1,0 +1,92 @@
+package dev.enro.test
+
+import dev.enro.NavigationContainer
+import dev.enro.NavigationKey
+import dev.enro.ui.NavigationContainerState
+import kotlin.reflect.KClass
+
+/**
+ * Asserts the container's backstack has exactly [expected] entries.
+ */
+public fun NavigationContainer.assertBackstackSize(expected: Int) {
+    enroAssert(backstack.size == expected) {
+        "Expected backstack to have $expected entries, but had ${backstack.size}: ${backstack.map { it.key }}"
+    }
+}
+
+public fun NavigationContainerState.assertBackstackSize(expected: Int): Unit =
+    container.assertBackstackSize(expected)
+
+/**
+ * Asserts the container's backstack contains exactly the given [keys] in order.
+ * Matches on key equality, not instance identity.
+ */
+public fun NavigationContainer.assertBackstackKeys(vararg keys: NavigationKey) {
+    val actual = backstack.map { it.key }
+    val expected = keys.toList()
+    enroAssert(actual == expected) {
+        "Expected backstack keys to be $expected, but was $actual"
+    }
+}
+
+public fun NavigationContainerState.assertBackstackKeys(vararg keys: NavigationKey): Unit =
+    container.assertBackstackKeys(*keys)
+
+/**
+ * Asserts the backstack contains at least one entry of [keyType], optionally
+ * matching [predicate]. Returns the first matching instance for further
+ * assertions.
+ */
+public fun <T : NavigationKey> NavigationContainer.assertBackstackContains(
+    keyType: KClass<T>,
+    predicate: (T) -> Boolean = { true },
+): NavigationKey.Instance<T> {
+    val matching = backstack
+        .filter { keyType.isInstance(it.key) }
+        .filter {
+            @Suppress("UNCHECKED_CAST")
+            predicate(it.key as T)
+        }
+    enroAssert(matching.isNotEmpty()) {
+        "Expected backstack to contain a ${keyType.simpleName} matching the predicate, " +
+            "but backstack was: ${backstack.map { it.key }}"
+    }
+    @Suppress("UNCHECKED_CAST")
+    return matching.first() as NavigationKey.Instance<T>
+}
+
+public inline fun <reified T : NavigationKey> NavigationContainer.assertBackstackContains(
+    noinline predicate: (T) -> Boolean = { true },
+): NavigationKey.Instance<T> = assertBackstackContains(T::class, predicate)
+
+public inline fun <reified T : NavigationKey> NavigationContainerState.assertBackstackContains(
+    noinline predicate: (T) -> Boolean = { true },
+): NavigationKey.Instance<T> = container.assertBackstackContains(T::class, predicate)
+
+/**
+ * Asserts the backstack does NOT contain any entry of [keyType].
+ */
+public fun NavigationContainer.assertBackstackDoesNotContain(keyType: KClass<out NavigationKey>) {
+    val matching = backstack.filter { keyType.isInstance(it.key) }
+    enroAssert(matching.isEmpty()) {
+        "Expected backstack to not contain any ${keyType.simpleName}, " +
+            "but found ${matching.size}: ${matching.map { it.key }}"
+    }
+}
+
+public inline fun <reified T : NavigationKey> NavigationContainer.assertBackstackDoesNotContain(): Unit =
+    assertBackstackDoesNotContain(T::class)
+
+public inline fun <reified T : NavigationKey> NavigationContainerState.assertBackstackDoesNotContain(): Unit =
+    container.assertBackstackDoesNotContain(T::class)
+
+/**
+ * Asserts the backstack is empty.
+ */
+public fun NavigationContainer.assertBackstackEmpty() {
+    enroAssert(backstack.isEmpty()) {
+        "Expected backstack to be empty, but had ${backstack.size} entries: ${backstack.map { it.key }}"
+    }
+}
+
+public fun NavigationContainerState.assertBackstackEmpty(): Unit = container.assertBackstackEmpty()

--- a/enro-test/src/commonMain/kotlin/dev/enro/test/NavigationContext.assertPath.kt
+++ b/enro-test/src/commonMain/kotlin/dev/enro/test/NavigationContext.assertPath.kt
@@ -1,0 +1,83 @@
+@file:OptIn(ExperimentalEnroApi::class)
+
+package dev.enro.test
+
+import dev.enro.EnroController
+import dev.enro.NavigationContext
+import dev.enro.NavigationKey
+import dev.enro.annotations.ExperimentalEnroApi
+import dev.enro.path.getNavigationKeyFromPath
+import dev.enro.path.getPathFromNavigationKey
+import kotlin.reflect.KClass
+
+/**
+ * Asserts [path] resolves to a [NavigationKey] of type [keyType] via the
+ * controller's registered path bindings, optionally matching [predicate].
+ * Returns the resolved key for further assertions.
+ */
+public fun <T : NavigationKey> EnroController.assertPathResolvesTo(
+    path: String,
+    keyType: KClass<T>,
+    predicate: (T) -> Boolean = { true },
+): T {
+    val resolved = getNavigationKeyFromPath(path)
+    resolved.shouldNotBeEqualTo(null) {
+        "Expected $path to resolve to ${keyType.simpleName}, but no registered path binding matched"
+    }
+    enroAssert(keyType.isInstance(resolved)) {
+        "Expected $path to resolve to ${keyType.simpleName}, but resolved to ${resolved!!::class.simpleName} ($resolved)"
+    }
+    @Suppress("UNCHECKED_CAST")
+    val typed = resolved as T
+    typed.shouldMatchPredicate(predicate) {
+        "Expected $path to resolve to a ${keyType.simpleName} matching the predicate, but got: $typed"
+    }
+    return typed
+}
+
+public inline fun <reified T : NavigationKey> EnroController.assertPathResolvesTo(
+    path: String,
+    noinline predicate: (T) -> Boolean = { true },
+): T = assertPathResolvesTo(path, T::class, predicate)
+
+public inline fun <reified T : NavigationKey> NavigationContext.assertPathResolvesTo(
+    path: String,
+    noinline predicate: (T) -> Boolean = { true },
+): T = controller.assertPathResolvesTo(path, T::class, predicate)
+
+/**
+ * Asserts [path] does NOT resolve to any [NavigationKey] via the controller's
+ * registered path bindings.
+ */
+public fun EnroController.assertPathDoesNotResolve(path: String) {
+    val resolved = runCatching { getNavigationKeyFromPath(path) }.getOrNull()
+    enroAssert(resolved == null) {
+        "Expected $path to not resolve, but it resolved to $resolved"
+    }
+}
+
+public fun NavigationContext.assertPathDoesNotResolve(path: String): Unit =
+    controller.assertPathDoesNotResolve(path)
+
+/**
+ * Asserts that serialising [key] via the controller's registered path bindings
+ * produces exactly [expectedPath]. Tests the reverse direction of
+ * `assertPathResolvesTo`.
+ */
+public fun EnroController.assertPathFor(
+    key: NavigationKey,
+    expectedPath: String,
+) {
+    val actual = getPathFromNavigationKey(key)
+    actual.shouldNotBeEqualTo(null) {
+        "Expected $key to serialise to $expectedPath, but no registered path binding matched"
+    }
+    actual.shouldBeEqualTo(expectedPath) {
+        "Expected $key to serialise to $expectedPath, but produced $actual"
+    }
+}
+
+public fun NavigationContext.assertPathFor(
+    key: NavigationKey,
+    expectedPath: String,
+): Unit = controller.assertPathFor(key, expectedPath)

--- a/enro-test/src/commonMain/kotlin/dev/enro/test/SyntheticDestinationTester.kt
+++ b/enro-test/src/commonMain/kotlin/dev/enro/test/SyntheticDestinationTester.kt
@@ -1,0 +1,141 @@
+@file:OptIn(AdvancedEnroApi::class)
+
+package dev.enro.test
+
+import dev.enro.NavigationContext
+import dev.enro.NavigationKey
+import dev.enro.annotations.AdvancedEnroApi
+import dev.enro.asInstance
+import dev.enro.test.fixtures.NavigationContainerFixtures
+import dev.enro.test.fixtures.NavigationContextFixtures
+import dev.enro.ui.NavigationDestinationProvider
+import dev.enro.ui.destinations.SyntheticOutcome
+import dev.enro.ui.destinations.peekSyntheticOutcome
+
+/**
+ * Executes the synthetic destination bound to [key] on the currently-installed
+ * navigation controller and returns the [SyntheticOutcome] the block decided on.
+ *
+ * Use this when the synthetic is registered through a `NavigationModule` on the
+ * controller — typical setup is `runEnroTest { MyComponent.installNavigationController(this); testSyntheticDestination(MyKey) }`.
+ *
+ * For unit-testing a synthetic's logic without installing a component, pass the
+ * provider directly: see the `testSyntheticDestination(key, provider, ...)` overload.
+ *
+ * Throws [IllegalStateException] if [key] isn't bound to a synthetic destination
+ * on the current controller.
+ */
+public fun <K : NavigationKey> testSyntheticDestination(
+    key: K,
+    fromContext: NavigationContext = NavigationContextFixtures.createRootContext(),
+): SyntheticOutcome {
+    val controller = EnroTest.getCurrentNavigationController()
+    return controller.peekSyntheticOutcome(key, fromContext)
+        ?: error(
+            "Key ${key::class.simpleName} is not bound to a synthetic destination on the current " +
+                "EnroController. Install a NavigationModule that registers the synthetic, or pass " +
+                "the NavigationDestinationProvider directly to the testSyntheticDestination(key, provider) overload."
+        )
+}
+
+/**
+ * Executes the synthetic destination bound to [provider] for [key] and returns
+ * the [SyntheticOutcome] the block decided on.
+ *
+ * Use this when you have a `val synthetic = syntheticDestination<K> { ... }` you
+ * want to unit-test without installing a controller component — pass the provider
+ * value directly.
+ *
+ * Throws [IllegalStateException] if [provider] isn't a synthetic destination.
+ */
+public fun <K : NavigationKey> testSyntheticDestination(
+    key: K,
+    provider: NavigationDestinationProvider<K>,
+    fromContext: NavigationContext = NavigationContextFixtures.createRootContext(),
+): SyntheticOutcome {
+    val instance = key.asInstance()
+    return provider.peekSyntheticOutcome(fromContext, instance)
+        ?: error(
+            "The provided NavigationDestinationProvider for ${key::class.simpleName} is not a " +
+                "synthetic destination — it doesn't carry the SyntheticDestinationKey metadata. " +
+                "Was the provider built with `syntheticDestination<K> { ... }`?"
+        )
+}
+
+/**
+ * Executes the side-effect block with default fixture context and container.
+ * Equivalent to calling [SyntheticOutcome.SideEffect.runWith] with freshly-built
+ * test fixtures — convenient when the side effect doesn't care about the
+ * specific context/container it's given.
+ */
+public fun SyntheticOutcome.SideEffect.runWith() {
+    val context = NavigationContextFixtures.createRootContext()
+    val containerState = NavigationContainerFixtures.create(parentContext = context)
+    runWith(context = context, container = containerState.container)
+}
+
+/**
+ * Asserts the outcome is [SyntheticOutcome.Open] of [Expected], optionally
+ * matching [keyPredicate]. Returns the opened key for further assertions.
+ */
+public inline fun <reified Expected : NavigationKey> SyntheticOutcome.assertOpens(
+    keyPredicate: (Expected) -> Boolean = { true },
+): Expected {
+    val open = this as? SyntheticOutcome.Open
+        ?: enroAssertionError("Expected synthetic to open ${Expected::class.simpleName}, but outcome was $this")
+    val key = open.key as? Expected
+        ?: enroAssertionError("Expected synthetic to open ${Expected::class.simpleName}, but opened ${open.key::class.simpleName}")
+    if (!keyPredicate(key)) {
+        enroAssertionError("Synthetic opened ${Expected::class.simpleName}, but the key didn't match the predicate; got: $key")
+    }
+    return key
+}
+
+/**
+ * Asserts the outcome is [SyntheticOutcome.CompleteFrom] of [Expected], optionally
+ * matching [keyPredicate]. Returns the forwarded key for further assertions.
+ */
+public inline fun <reified Expected : NavigationKey> SyntheticOutcome.assertCompletesFrom(
+    keyPredicate: (Expected) -> Boolean = { true },
+): Expected {
+    val completeFrom = this as? SyntheticOutcome.CompleteFrom
+        ?: enroAssertionError("Expected synthetic to completeFrom ${Expected::class.simpleName}, but outcome was $this")
+    val key = completeFrom.key as? Expected
+        ?: enroAssertionError("Expected synthetic to completeFrom ${Expected::class.simpleName}, but completed from ${completeFrom.key::class.simpleName}")
+    if (!keyPredicate(key)) {
+        enroAssertionError("Synthetic completed from ${Expected::class.simpleName}, but the key didn't match the predicate; got: $key")
+    }
+    return key
+}
+
+/**
+ * Asserts the outcome is a close, optionally matching the silent flag.
+ */
+public fun SyntheticOutcome.assertCloses(silent: Boolean? = null) {
+    val close = this as? SyntheticOutcome.Close
+        ?: enroAssertionError("Expected synthetic to close, but outcome was $this")
+    if (silent != null && close.silent != silent) {
+        enroAssertionError("Expected close with silent=$silent, but got silent=${close.silent}")
+    }
+}
+
+/**
+ * Asserts the outcome is a complete with the expected payload. Pass `null` for
+ * non-result synthetics that call `complete()`.
+ */
+public fun SyntheticOutcome.assertCompletes(expectedResult: Any?) {
+    val complete = this as? SyntheticOutcome.Complete
+        ?: enroAssertionError("Expected synthetic to complete, but outcome was $this")
+    if (complete.result != expectedResult) {
+        enroAssertionError("Expected complete with result $expectedResult, but got ${complete.result}")
+    }
+}
+
+/**
+ * Asserts the outcome is a side effect and returns it for further assertion
+ * (e.g. calling [SyntheticOutcome.SideEffect.runWith] to execute it).
+ */
+public fun SyntheticOutcome.assertSideEffect(): SyntheticOutcome.SideEffect {
+    return this as? SyntheticOutcome.SideEffect
+        ?: enroAssertionError("Expected synthetic to produce a side effect, but outcome was $this")
+}

--- a/enro-test/src/commonMain/kotlin/dev/enro/test/TestNavigationHandle.lastOperation.kt
+++ b/enro-test/src/commonMain/kotlin/dev/enro/test/TestNavigationHandle.lastOperation.kt
@@ -1,0 +1,48 @@
+package dev.enro.test
+
+import dev.enro.NavigationOperation
+import kotlin.reflect.KClass
+
+/**
+ * Returns the most-recently executed operation. Throws if no operations have
+ * been executed yet — use `operations.lastOrNull()` directly if you need
+ * to handle the empty case.
+ */
+public fun TestNavigationHandle<*>.lastOperation(): NavigationOperation.RootOperation {
+    val last = operations.lastOrNull()
+    last.shouldNotBeEqualTo(null) {
+        "TestNavigationHandle should have executed at least one operation, but none were executed"
+    }
+    return last!!
+}
+
+/**
+ * Returns the most-recently executed operation of type [T], or throws if no
+ * operation of that type has been executed. Useful when you want to drill
+ * into operation-specific fields (instance, result, etc.) without filtering
+ * the whole `operations` list manually.
+ */
+public inline fun <reified T : NavigationOperation.RootOperation> TestNavigationHandle<*>.lastOperationOfType(): T {
+    val matching = operations.filterIsInstance<T>()
+    matching.lastOrNull().shouldNotBeEqualTo(null) {
+        "TestNavigationHandle should have executed at least one ${T::class.simpleName}, " +
+            "but none were found.\n\tOperations: $operations"
+    }
+    return matching.last()
+}
+
+/**
+ * Asserts the executed operations match [expectedSequence] exactly in order
+ * and count. Compares operation types by `KClass`, not by content — for
+ * field-level assertions, use [assertOperationExecuted] per step.
+ */
+public fun TestNavigationHandle<*>.assertOperationSequence(
+    vararg expectedSequence: KClass<out NavigationOperation.RootOperation>,
+) {
+    val actualTypes = operations.map { it::class }
+    val expectedTypes = expectedSequence.toList()
+    enroAssert(actualTypes == expectedTypes) {
+        "Expected operation sequence ${expectedTypes.map { it.simpleName }}, " +
+            "but executed ${actualTypes.map { it.simpleName }}.\n\tOperations: $operations"
+    }
+}

--- a/enro-test/src/commonMain/kotlin/dev/enro/test/installNavigationModule.kt
+++ b/enro-test/src/commonMain/kotlin/dev/enro/test/installNavigationModule.kt
@@ -1,0 +1,32 @@
+@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+
+package dev.enro.test
+
+import dev.enro.controller.NavigationModule
+import dev.enro.controller.createNavigationModule
+import dev.enro.path.NavigationPathBinding
+
+/**
+ * Installs [module] onto the test controller managed by [runEnroTest].
+ *
+ * Replaces the verbose `EnroTest.getCurrentNavigationController().addModule(module)`
+ * pattern that nearly every path-binding or interceptor test repeats. Must be
+ * called from inside a `runEnroTest { }` block; throws if no controller is
+ * installed.
+ */
+public fun installNavigationModule(module: NavigationModule) {
+    EnroTest.getCurrentNavigationController().addModule(module)
+}
+
+/**
+ * Convenience for the common case of installing a small set of
+ * [NavigationPathBinding]s for a path-routing test, without manually wrapping
+ * them in a `createNavigationModule { path(...) }` block.
+ */
+public fun installPathBindings(vararg bindings: NavigationPathBinding<*>) {
+    installNavigationModule(
+        createNavigationModule {
+            bindings.forEach { path(it) }
+        }
+    )
+}


### PR DESCRIPTION
## Summary

Two themes bundled into one PR — both closing out items on the post-web-routing roadmap's DX tier:

### 1. Synthetic destination unit testing (the marquee feature)

Multiple users have asked for a way to unit-test synthetic destinations. Until now there wasn't one: synthetics don't get a `NavigationHandle`, and the boilerplate to exercise one in isolation was roughly the `openSynthetic` helper buried in the internal `SyntheticDestinationTests`. Now there's a first-class API.

Two entry points cover the two real test shapes:

```kotlin
// Registered path — synthetic is installed on the test controller
@Test
fun `auth gate forwards to protected screen when logged in`() = runEnroTest {
    MyComponent.installNavigationController(this)
    isLoggedIn = true
    testSyntheticDestination(RequireProtectedFeature)
        .assertOpens<AuthGateProtectedFeature>()
}

// Direct path — provider passed in, no controller install needed
val authGate = syntheticDestination<RequireProtectedFeature> {
    if (sessionRepository.isLoggedIn) open(AuthGateProtectedFeature)
    else open(AuthGateLogin)
}

@Test
fun `auth gate redirects to login when logged out`() {
    sessionRepository.signOut()
    testSyntheticDestination(RequireProtectedFeature, authGate)
        .assertOpens<AuthGateLogin>()
}
```

Plus an assertion DSL: `assertOpens<T>`, `assertCompletesFrom<T>`, `assertCloses(silent?)`, `assertCompletes(result)`, `assertSideEffect()`. The `SideEffect` outcome carries the block but doesn't auto-invoke — `runWith(context?, container?)` lets the test choose when and against what scope. A zero-argument `runWith()` overload uses fixture defaults for the common "I don't care about the scope, I just want to run it" case.

Two new `@AdvancedEnroApi` extensions in `enro-runtime` back the test helpers without exposing the synthetic dispatcher's internal sealed-class hierarchy:

```kotlin
NavigationDestinationProvider<K>.peekSyntheticOutcome(context, instance): SyntheticOutcome?
EnroController.peekSyntheticOutcome(key, context): SyntheticOutcome?
```

The runtime's own dispatcher is unchanged — this is a parallel surface designed for unit testing, returning a plain value (not the thrown sentinel).

### 2. Four ergonomic helpers from the DX roadmap

Each is a thin wrapper over an existing API that previously needed several lines of boilerplate per test.

| Category | Helpers |
|---|---|
| Backstack | `assertBackstackKeys`, `assertBackstackSize`, `assertBackstackContains<T>`, `assertBackstackDoesNotContain<T>`, `assertBackstackEmpty` (on `NavigationContainer` and `NavigationContainerState`) |
| Module setup | `installNavigationModule(module)`, `installPathBindings(vararg)` |
| Path resolution | `assertPathResolvesTo<T>(path, predicate?)`, `assertPathDoesNotResolve(path)`, `assertPathFor(key, expectedPath)` (on `EnroController` and `NavigationContext`) |
| Operation history | `lastOperation()`, `lastOperationOfType<T>()`, `assertOperationSequence(*KClass)` |

These were the four items called out in the roadmap as "concrete from writing the recent path tests." They each collapse repeated 3–5 line patterns to a single line.

## Why

For (1): synthetics are powerful precisely *because* they're tiny decision points — and that's exactly the kind of code that's easiest to unit-test if there's a sandbox for it. The API surface they expose makes that sandbox cheap: the outcome model is small (5 variants), each outcome is value-shaped, and the side-effect case carries enough information for a test to inspect or execute it as the test sees fit. Shipping the testing API closes the loop on the synthetic redesign from PRs #212/#213.

For (2): every path-binding test we've written in the last few PRs hit the same boilerplate. Putting these helpers in once means future tests don't.

## What's NOT in this PR

- **NavigationHandle KDoc** — separate Tier 3 item, still open.
- **`@NavigationPath` user guide page** — separate Tier 3 item.
- **Module READMEs / Dokka** — separate Tier 3 items.

## API shape (public surface added)

```
enro-runtime:
  sealed class SyntheticOutcome
    data class Open(instance) : SyntheticOutcome
    data class Close(silent: Boolean) : SyntheticOutcome
    data class Complete(result: Any?) : SyntheticOutcome
    data class CompleteFrom(instance) : SyntheticOutcome
    class SideEffect : SyntheticOutcome  // runWith(context, container)

  @AdvancedEnroApi
  NavigationDestinationProvider<K>.peekSyntheticOutcome(context, instance): SyntheticOutcome?

  @AdvancedEnroApi
  EnroController.peekSyntheticOutcome(key, context): SyntheticOutcome?

enro-test:
  testSyntheticDestination(key, fromContext?): SyntheticOutcome
  testSyntheticDestination(key, provider, fromContext?): SyntheticOutcome
  SyntheticOutcome.SideEffect.runWith()                    // no-arg overload with fixtures
  SyntheticOutcome.assertOpens<T>(predicate?)
  SyntheticOutcome.assertCompletesFrom<T>(predicate?)
  SyntheticOutcome.assertCloses(silent?)
  SyntheticOutcome.assertCompletes(expectedResult)
  SyntheticOutcome.assertSideEffect()

  NavigationContainer.assertBackstack* (5 helpers)
  installNavigationModule(module), installPathBindings(vararg)
  EnroController/NavigationContext.assertPath* (3 helpers)
  TestNavigationHandle.lastOperation(), lastOperationOfType<T>(), assertOperationSequence(*KClass)
```

## Test plan

- [ ] `./gradlew :enro-runtime:desktopTest` — full suite green; 13 new tests in `SyntheticDestinationTesterTests` + 16 in `EnroTestHelpersTests` (29 total new tests).
- [ ] `./gradlew :enro-test:compileKotlinDesktop` — new helpers compile.
- [ ] `./gradlew :enro-compat:compileDebugKotlinAndroid` — compat still compiles against the unchanged synthetic dispatcher.
- [ ] `./gradlew :enro-runtime:compileKotlinWasmJs` — wasmJs target compiles against the new public API.
- [ ] Spot-check the docs render: `docs/advanced/synthetic-destinations.md` gained a "Testing synthetic destinations" section with both entry points + the assertion table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)