### PR TITLE
Tier 3 DX bundle: NavigationHandle KDoc, module READMEs, path-bindings docs, Dokka

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ That's the whole flow. See [enro.dev](https://enro.dev) for the full guide.
 
 - **Documentation:** [enro.dev](https://enro.dev) — installation, concepts, results, animations, testing, platform guides, and the migration guide from Enro 2.
 - **Recipes:** [`recipes/`](./recipes/src/commonMain/kotlin/dev/enro/recipes) — every concept (dialogs, bottom sheets, list-detail, tabs, deep links, managed flows, shared view models, custom animations) is a small runnable sample.
+- **API reference:** generate with `./gradlew dokkaGenerate`; the multi-module site lands at `build/dokka/html/index.html`. Also published as a `-javadoc.jar` alongside each artifact on Maven Central.
 - **Changelog:** [CHANGELOG.md](./CHANGELOG.md).
 
 ## Migrating from Enro 2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,26 @@ buildscript {
         classpath(libs.processing.ksp.gradle)
         classpath(libs.emulator.wtf.gradle)
         classpath(libs.maven.publish.gradle)
+        classpath(libs.dokka.gradle)
     }
+}
+
+// Aggregate API reference site: each published module is registered as
+// a `dokka(...)` dependency below, and the root `dokkaGenerate` task
+// combines their per-module outputs into one multi-module HTML site at
+// `build/dokka/html`. Per-module Dokka is wired up in
+// `ConfigurePublishing` — anything that doesn't apply
+// `configure-publishing` is excluded from the API reference.
+apply(plugin = "org.jetbrains.dokka")
+
+dependencies {
+    "dokka"(project(":enro"))
+    "dokka"(project(":enro-annotations"))
+    "dokka"(project(":enro-common"))
+    "dokka"(project(":enro-compat"))
+    "dokka"(project(":enro-processor"))
+    "dokka"(project(":enro-runtime"))
+    "dokka"(project(":enro-test"))
 }
 
 allprojects {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation(libs.compose.gradle)
     implementation(libs.emulator.wtf.gradle)
     implementation(libs.maven.publish.gradle)
+    implementation(libs.dokka.gradle)
 }
 
 

--- a/buildSrc/src/main/kotlin/ConfigurePublishing.kt
+++ b/buildSrc/src/main/kotlin/ConfigurePublishing.kt
@@ -23,6 +23,7 @@ class ConfigurePublishing : Plugin<Project> {
             with(pluginManager) {
                 apply("com.vanniktech.maven.publish")
                 apply("signing")
+                apply("org.jetbrains.dokka")
             }
 
             val localProperties = Properties()

--- a/docs/ghpages/docs/advanced/path-bindings.md
+++ b/docs/ghpages/docs/advanced/path-bindings.md
@@ -1,0 +1,238 @@
+---
+title: Path Bindings
+parent: Advanced Topics
+nav_order: 7
+---
+
+# Path Bindings
+
+A path binding maps a URL path pattern to a `NavigationKey` type, and
+back again. Once a key has a binding, the runtime can:
+
+- **Resolve a path to a key** — turn `/products/abc?source=email` into
+  `ProductDetail(productId = "abc", source = "email")` for deep-link
+  handling.
+- **Serialise a key to a path** — turn that same key back into the URL
+  the web history plugin shows in the address bar.
+
+The same `@NavigationPath` annotation works on every platform. On Web
+it drives the URL bar; on Android / iOS / Desktop it backs deep-link
+parsing without you having to wire up Intent filters or custom URL
+schemes yourself. (Inbound deep links still arrive through the
+platform's own mechanism — `intent.data`, `application(_:openURL:)`,
+custom URI handlers — but once you have the string, `getNavigationKeyFromPath`
+turns it into a key you can `open()`.)
+
+`@NavigationPath` and its companions are currently marked
+`@ExperimentalEnroApi` while the API surface stabilises through the
+3.x cycle. The shape is unlikely to shift meaningfully, but expect
+small refinements before the API graduates.
+
+## Simple usage
+
+Annotate the key with `@NavigationPath("/pattern/with/{placeholders}")`:
+
+```kotlin
+@Serializable
+@NavigationPath("/products/{productId}")
+data class ProductDetail(
+    val productId: String,
+) : NavigationKey
+```
+
+The processor reads the pattern, matches each `{placeholder}` to a
+property on the key (by name), and generates the binding. At runtime
+the controller will accept `/products/shoe-1` and produce
+`ProductDetail("shoe-1")`; calling `controller.getPathFromNavigationKey(ProductDetail("shoe-1"))`
+returns `/products/shoe-1`.
+
+Properties that aren't part of the path produce a compile-time error
+unless they have default values — there has to be something for the
+deserialiser to plug into them.
+
+## Query parameters and optionals
+
+Append `?key={value}` (or `&key={value}`) for query parameters. Mark
+optional parameters with a trailing `?` inside the braces:
+
+```kotlin
+@Serializable
+@NavigationPath("/products/{productId}?source={source?}&campaign={campaign?}")
+data class ProductDetail(
+    val productId: String,
+    val source: String? = null,
+    val campaign: String? = null,
+) : NavigationKey
+```
+
+Now `/products/shoe-1`, `/products/shoe-1?source=email`, and
+`/products/shoe-1?source=email&campaign=spring-sale` all resolve;
+absent params land as `null` on the key.
+
+## Value classes
+
+Inline value classes serialise through their backing field, so they
+work as path properties as long as the underlying type is supported
+(`String`, primitive numerics, `Boolean`):
+
+```kotlin
+@JvmInline
+@Serializable
+value class ProductId(val value: String)
+
+@Serializable
+@NavigationPath("/products/{productId}")
+data class ProductDetail(
+    val productId: ProductId,
+) : NavigationKey
+```
+
+The URL is still `/products/shoe-1` — the value class is transparent
+at the path layer.
+
+## Custom bindings with `@NavigationPath.FromBinding`
+
+Property-by-name matching covers most cases. When it doesn't — you
+want to default missing fields to non-trivial values, derive one
+property from another, or hand-write the serialiser — declare a
+`NavigationKey.PathBinding<T>` and point at it with
+`@NavigationPath.FromBinding`:
+
+```kotlin
+@Serializable
+@NavigationPath("/items/{id}?name={name}&title={title?}")
+@NavigationPath.FromBinding(MyKey.Default::class)
+data class MyKey(
+    val id: String,
+    val name: String,
+    val title: String? = null,
+) : NavigationKey {
+
+    object Default : NavigationKey.PathBinding<MyKey> {
+        // Fallback shape — used when the URL is just /items with a title.
+        override val pattern: String = "/items?title={title?}"
+
+        override fun deserialize(data: PathData): MyKey {
+            return MyKey(
+                id = "default-id",
+                name = "default-name",
+                title = data.optional("title"),
+            )
+        }
+
+        override fun serialize(builder: PathData.Builder, key: MyKey) {
+            key.title?.let { builder.set("title", it) }
+        }
+    }
+}
+```
+
+A key can carry **one primary pattern** (the `@NavigationPath` value)
+plus **any number of `FromBinding` patterns**. Resolution tries each
+pattern in turn; the first match wins. This is what lets you support
+short / long forms of the same URL ("`/items/abc`" and "`/items`" both
+producing some `MyKey`).
+
+The `PathData` / `PathData.Builder` API exposes typed accessors for
+the parsed path segments and query parameters. See `dev.enro.path.PathData`
+for the surface.
+
+## Programmatic bindings (no annotation)
+
+When you can't (or don't want to) annotate the key — typically because
+the key is defined in a module you don't control — register the binding
+directly through `NavigationPathBinding.createPathBinding(…)`:
+
+```kotlin
+val productDetailBinding: NavigationPathBinding<ProductDetail> =
+    NavigationPathBinding.createPathBinding(
+        pattern = "/products/{productId}?source={source?}",
+        propertyOne = ProductDetail::productId,
+        propertyTwo = ProductDetail::source,
+        constructor = ::ProductDetail,
+    )
+
+val pathsModule = createNavigationModule {
+    path(productDetailBinding)
+}
+```
+
+The annotation form is just sugar over this API — the processor
+generates equivalent `createPathBinding(…)` calls and registers them
+on the component.
+
+## Resolving paths at runtime
+
+Two functions, mirror images of each other:
+
+```kotlin
+// String → Key
+@ExperimentalEnroApi
+fun EnroController.getNavigationKeyFromPath(path: String): NavigationKey?
+
+// Key → String
+@ExperimentalEnroApi
+fun EnroController.getPathFromNavigationKey(key: NavigationKey): String?
+```
+
+`NavigationHandle` and `NavigationContext` have receiver versions of
+both for convenience inside destinations — see the
+`NavigationHandle.getNavigationKeyFromPath` / `getPathFromNavigationKey`
+KDoc. Both return `null` when no binding matches: an unrecognised path
+or a key whose type has no binding registered.
+
+Typical use:
+
+```kotlin
+// Handling an inbound Android deep link.
+override fun onNewIntent(intent: Intent) {
+    val key = controller.getNavigationKeyFromPath(intent.dataString.orEmpty()) ?: return
+    rootHandle.open(key)
+}
+```
+
+## The path-vs-state model
+
+A common question: "Why doesn't my modal / tab / inner-container
+destination show up in the URL?"
+
+Enro's web URL routing is **root-container-only** — only the active
+destination of the root navigation container is reflected in the URL
+bar. Modals, sheets, inner tabs, list/detail panes hosted inside
+other destinations are *state*, not *URL state*, and don't write to
+`location.pathname`.
+
+This is deliberate, and matches how most modern web apps behave:
+
+- Going to a different *page* on Twitter writes the URL
+  (`/elonmusk/status/123`).
+- Switching tabs within a profile (Tweets / Replies / Media) doesn't.
+
+Path bindings declare what's URL-shaped; the runtime treats unbound
+destinations as session-local. If you have a destination that you'd
+like to be deep-linkable but it lives inside a nested container, the
+two options are:
+
+1. Promote it to root for the URL-bound case (and host the same
+   destination inside a parent for the nested case — same key, two
+   contexts).
+2. Use the synthetic-backstack pattern from the *Advanced Deep Link*
+   recipe: parse the URL yourself, derive the parent context, seed the
+   nested container's backstack manually.
+
+The web platform docs cover the URL/history wiring in detail — see
+[Web Platform Guide](../platform/web.md) for `EnroBrowserContent`,
+`InstallWebHistoryPlugin`, and `rememberInitialBackstackFromUrl`.
+
+## See also
+
+- [Web Platform Guide](../platform/web.md) — how `@NavigationPath`
+  drives browser URL routing.
+- [Synthetic Destinations](synthetic-destinations.md) — pairs well
+  with path bindings for "URL hits → decide which screen to show".
+- Recipes: [Basic Deep Link][basic-deep-link],
+  [Advanced Deep Link][advanced-deep-link] — full working examples of
+  annotated and programmatic bindings respectively.
+
+[basic-deep-link]: https://github.com/isaac-udy/Enro/blob/main/recipes/src/commonMain/kotlin/dev/enro/recipes/deeplink/BasicDeepLink.kt
+[advanced-deep-link]: https://github.com/isaac-udy/Enro/blob/main/recipes/src/commonMain/kotlin/dev/enro/recipes/deeplink/AdvancedDeepLink.kt

--- a/docs/ghpages/docs/advanced/path-bindings.md
+++ b/docs/ghpages/docs/advanced/path-bindings.md
@@ -204,9 +204,10 @@ other destinations are *state*, not *URL state*, and don't write to
 
 This is deliberate, and matches how most modern web apps behave:
 
-- Going to a different *page* on Twitter writes the URL
-  (`/elonmusk/status/123`).
-- Switching tabs within a profile (Tweets / Replies / Media) doesn't.
+- Navigating to a different page on this very docs site writes the URL
+  (`/docs/advanced/path-bindings`).
+- Toggling the sidebar nav, jumping to a heading, or expanding a
+  collapsible code block doesn't.
 
 Path bindings declare what's URL-shaped; the runtime treats unbound
 destinations as session-local. If you have a destination that you'd

--- a/docs/ghpages/docs/advanced/path-bindings.md
+++ b/docs/ghpages/docs/advanced/path-bindings.md
@@ -204,10 +204,10 @@ other destinations are *state*, not *URL state*, and don't write to
 
 This is deliberate, and matches how most modern web apps behave:
 
-- Navigating to a different page on this very docs site writes the URL
-  (`/docs/advanced/path-bindings`).
-- Toggling the sidebar nav, jumping to a heading, or expanding a
-  collapsible code block doesn't.
+- Going to a different profile on Bluesky writes the URL
+  (`bsky.app/profile/some.handle`).
+- Switching tabs within that profile (Posts / Replies / Media /
+  Videos / Likes / Feeds) doesn't — the URL stays on the profile.
 
 Path bindings declare what's URL-shaped; the runtime treats unbound
 destinations as session-local. If you have a destination that you'd

--- a/enro-annotations/README.md
+++ b/enro-annotations/README.md
@@ -1,0 +1,41 @@
+# `enro-annotations`
+
+The annotations consumed by [`enro-processor`](../enro-processor/) to
+generate destination registrations and path bindings, plus the opt-in
+marker annotations (`@AdvancedEnroApi`, `@ExperimentalEnroApi`) used
+throughout the Enro public API.
+
+This module exists as a thin, dependency-free artefact so consumers can
+reference Enro annotations without pulling in the full runtime — useful
+for:
+
+- KMP modules with non-UI targets that share `NavigationKey` definitions
+  but never render UI (paired with [`enro-common`](../enro-common/)).
+- Build-time tooling that needs to read Enro annotations without taking
+  a Compose / Android runtime dependency.
+
+## What's in here
+
+- `@NavigationDestination(keyType)` — marks a Composable / Fragment /
+  Activity as the destination for a given `NavigationKey` type.
+- `@NavigationComponent` — marks the class whose generated companion
+  becomes your component's `installNavigationController(…)` entry point.
+- `@NavigationPath(pattern)` — declares a URL pattern for a
+  `NavigationKey`, enabling deep-link / web-routing resolution.
+- `@AdvancedEnroApi`, `@ExperimentalEnroApi` — opt-in markers for
+  surfaces that aren't part of the stable API contract.
+- `@GeneratedNavigationBinding`, `@GeneratedNavigationComponent` —
+  emitted by the processor; not for hand-use.
+
+## Typical usage
+
+Pulled in transitively when you depend on `dev.enro:enro` or
+`enro-runtime`. Depend on `enro-annotations` directly only when you
+want the annotation types without the rest of the runtime (e.g. in a
+`:common` KMP module shared with non-Compose targets).
+
+```kotlin
+dependencies {
+    implementation("dev.enro:enro-annotations:3.0.0-alpha10")
+}
+```

--- a/enro-processor/README.md
+++ b/enro-processor/README.md
@@ -1,0 +1,50 @@
+# `enro-processor`
+
+The KSP / kapt code generator that turns `@NavigationDestination`,
+`@NavigationComponent`, and `@NavigationPath` annotations into the glue
+the runtime consumes. Apply it as a `ksp("…")` dependency on any module
+that declares Enro destinations; it generates:
+
+- A per-component **`*Navigation`** class that registers every annotated
+  destination (and path binding) with the runtime when you call
+  `installNavigationController(…)`. This is what lets you write a
+  destination once and have it discovered automatically — no manual
+  `registerDestination(…)` boilerplate.
+- **Path-binding** glue for `@NavigationPath`, including the
+  serialisers needed to bridge URL segments to typed `NavigationKey`
+  properties.
+- Per-destination metadata (key type, render kind, optional metadata
+  overrides) so the runtime can resolve `open(KeyType)` calls without
+  reflection at runtime.
+
+The processor itself is pure JVM — it has no multiplatform target — but
+its output is multiplatform-aware and lands in the right source set per
+target.
+
+## Typical usage
+
+You don't usually add `enro-processor` to a module directly. The
+`dev.enro:enro` meta-artefact takes care of pulling it in alongside the
+runtime; the KSP wiring you write looks like:
+
+```kotlin
+plugins {
+    id("com.google.devtools.ksp")
+}
+
+dependencies {
+    implementation("dev.enro:enro:3.0.0-alpha10")
+    ksp("dev.enro:enro-processor:3.0.0-alpha10")
+}
+```
+
+For multi-target KMP modules, attach the processor to every target source
+set that declares destinations (e.g. `kspCommonMainMetadata`,
+`kspAndroid`, `kspIosArm64`, etc.). The output classes are then visible
+on each platform.
+
+## When to depend on this directly
+
+Only when you're building tooling that needs to invoke the processor
+outside the standard `ksp(…)` flow (e.g. a custom build plugin that
+generates extra glue from the same annotations).

--- a/enro-runtime/README.md
+++ b/enro-runtime/README.md
@@ -1,0 +1,54 @@
+# `enro-runtime`
+
+The runtime engine of Enro. Defines the public API every Enro app touches
+at runtime: [`NavigationKey`](src/commonMain/kotlin/dev/enro/NavigationKey.kt),
+[`NavigationHandle`](src/commonMain/kotlin/dev/enro/NavigationHandle.kt),
+[`NavigationContainer`](src/commonMain/kotlin/dev/enro/NavigationContainer.kt),
+[`NavigationDisplay`](src/commonMain/kotlin/dev/enro/ui/NavigationDisplay.kt),
+plus the operation / scene / result-channel machinery that makes them
+work. If you're declaring a destination or driving navigation from
+inside one, you're using this module.
+
+Targets **Android, iOS, JVM Desktop, and WASM JS** through Compose
+Multiplatform. Non-UI definitions that need to be shared with non-UI
+targets (e.g. a NodeJS backend) live in [`enro-common`](../enro-common/)
+instead — `enro-runtime` re-exports them.
+
+## What's in here
+
+- **Keys & handles** — `NavigationKey` (the screen contract),
+  `NavigationKey.WithResult` (typed completion), `NavigationHandle` (the
+  destination's view of the runtime).
+- **Containers & operations** — `NavigationContainer` (a hosted
+  backstack), `NavigationOperation` (Open / Close / Complete /
+  CompleteFrom / SetBackstack and their aggregates).
+- **Scenes & display** — `NavigationDisplay` (Compose renderer),
+  `NavigationSceneStrategy` / `SceneDecoratorStrategy` (how a backstack
+  becomes a scene tree), built-in `SinglePane` / `Dialog` / `DirectOverlay`
+  scene strategies.
+- **Results** — `registerForNavigationResult` (the caller's side),
+  `NavigationKey.WithResult.complete(…)` (the callee's side),
+  `NavigationFlow` (multi-step flows).
+- **Path bindings** — `@NavigationPath` and the path-resolution APIs that
+  turn URLs into keys and back, used for deep-linking and web routing.
+- **Synthetic destinations** — `syntheticDestination<K> { … }` for keys
+  whose "destination" is a synchronous decision, not UI (auth gates,
+  external URL launchers, redirects).
+
+## Typical usage
+
+Apps usually depend on the meta-module `dev.enro:enro`, which pulls in
+`enro-runtime` along with the KSP processor and a sensible default
+configuration. Depending on `enro-runtime` directly is for advanced
+setups (custom processors, slimmer artefacts).
+
+```kotlin
+dependencies {
+    implementation("dev.enro:enro:3.0.0-alpha10")
+    ksp("dev.enro:enro-processor:3.0.0-alpha10")
+}
+```
+
+See the root [README](../README.md) for a working "define a key, render
+a destination, navigate" example, and [enro.dev](https://enro.dev) for
+the full guide.

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/NavigationHandle.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/NavigationHandle.kt
@@ -2,31 +2,112 @@ package dev.enro
 
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.SavedStateHandle
-import dev.enro.annotations.AdvancedEnroApi
 import kotlin.jvm.JvmName
 
+/**
+ * The active destination's view of the navigation framework.
+ *
+ * A [NavigationHandle] represents a single live entry on the backstack —
+ * one instance, one lifecycle, one [SavedStateHandle]. From inside a
+ * destination you use it to talk back to the navigation system: open
+ * another destination, close yourself, complete with a result, etc.
+ *
+ * Get one via:
+ * - `navigationHandle()` inside a `@Composable` destination
+ * - `by navigationHandle()` as a delegated property in a `ViewModel`
+ * - `viewModelStoreOwner.getNavigationHandle<MyKey>()` from a Fragment / Activity
+ *
+ * The handle is always typed to the [NavigationKey] subtype that started
+ * the destination, so completion APIs that depend on the key's result type
+ * (see [NavigationKey.WithResult]) stay statically checked.
+ *
+ * Implements [LifecycleOwner]: the handle's lifecycle tracks the
+ * destination's lifecycle (created → started → resumed → … → destroyed),
+ * so anything scoped to it (coroutines, observers) cleans up automatically
+ * when the destination leaves the backstack.
+ *
+ * @param T the [NavigationKey] subtype this handle was created for.
+ */
 public abstract class NavigationHandle<out T : NavigationKey> internal constructor() : LifecycleOwner {
+    /**
+     * State that survives configuration changes and process death for this
+     * destination. Wraps the platform's `SavedStateHandle` and is scoped to
+     * this entry — different backstack entries for the same key each get
+     * their own.
+     */
     public abstract val savedStateHandle: SavedStateHandle
 
+    /**
+     * The backstack entry this handle was attached to: the [NavigationKey]
+     * plus a stable id and any metadata layered onto it. Prefer [instance]
+     * over [key] when you need the id (e.g. to compare against other
+     * backstack entries) or metadata; use [key] when you only need the
+     * key's data.
+     */
     public abstract val instance: NavigationKey.Instance<T>
+
+    /**
+     * Shorthand for `instance.key`. Same value object that the caller
+     * passed to `open(…)` / put in the initial backstack — its properties
+     * are the key's serialised fields.
+     */
     public val key: T get() = instance.key
 
     @Deprecated("Use instance")
     public val instruction: NavigationKey.Instance<T> get() = instance
 
+    /**
+     * Low-level entry point that dispatches a [NavigationOperation] through
+     * the controller. The strongly-typed helpers ([open], [close],
+     * [complete], [completeFrom], [closeAndReplaceWith],
+     * [closeAndCompleteFrom]) cover every common case; call [execute]
+     * directly only when you need to compose an operation those helpers
+     * don't already build — e.g. a custom [NavigationOperation.SetBackstack]
+     * or a hand-rolled [NavigationOperation.AggregateOperation].
+     */
     public abstract fun execute(
         operation: NavigationOperation,
     )
 }
 
+/**
+ * Asks the destination to close itself, routing through any
+ * `onCloseRequested` callback registered via [NavigationHandleConfiguration].
+ *
+ * If a callback is registered it runs in place of the default close — that's
+ * how a destination opts in to "prompt before dismissing" behaviour by
+ * showing a confirmation dialog and only invoking [close] when the user
+ * confirms. With no callback registered this is equivalent to [close].
+ *
+ * This is the function predictive-back and system-back gestures invoke, so
+ * if you want gesture-triggered close to route through your confirmation
+ * UI, register the callback (and DO NOT call [close] directly elsewhere).
+ */
 public fun NavigationHandle<*>.requestClose() {
     NavigationHandleConfiguration.onCloseRequested(this)
 }
 
+/**
+ * Closes this destination unconditionally — removes it from the backstack
+ * and tears down its lifecycle.
+ *
+ * Bypasses any registered `onCloseRequested` callback; use [requestClose]
+ * if you want the registered callback to have a chance to intervene
+ * (typical for system-back / "X" button affordances).
+ */
 public fun NavigationHandle<*>.close() {
     execute(NavigationOperation.Close(instance))
 }
 
+/**
+ * Completes a non-result destination — closes this entry and notifies
+ * the opener that the work finished successfully.
+ *
+ * Use this for navigation keys with no result payload. For
+ * [NavigationKey.WithResult] keys, call the result-carrying overload
+ * `complete(result)` instead — completing a result key without a result
+ * is a programming error and produces a deprecation-level error.
+ */
 public fun NavigationHandle<*>.complete() {
     execute(NavigationOperation.Complete(instance))
 }
@@ -40,10 +121,29 @@ public fun <R : Any> NavigationHandle<NavigationKey.WithResult<R>>.complete() {
     error("${instance.key} is a NavigationKey.WithResult and cannot be completed without a result")
 }
 
+/**
+ * Completes this result-bearing destination with [result], closes it, and
+ * delivers the value back to whoever opened it.
+ *
+ * The opener receives the result through the `registerForNavigationResult`
+ * channel they set up before opening this key.
+ */
 public fun <R : Any> NavigationHandle<NavigationKey.WithResult<R>>.complete(result: R) {
     execute(NavigationOperation.Complete(instance, result))
 }
 
+/**
+ * Forwards completion of this destination to another navigation [key].
+ *
+ * Used by *intermediary* destinations that delegate to a downstream
+ * destination: this entry closes, [key] is opened in its place, and when
+ * [key] eventually completes its result is delivered to whoever originally
+ * opened *this* entry. Lets you wedge a chooser / disambiguator in front
+ * of a result-producing destination without the opener knowing.
+ *
+ * For result-typed destinations, prefer the [NavigationKey.WithResult]
+ * overload, which enforces matching result types at compile time.
+ */
 public fun NavigationHandle<NavigationKey>.completeFrom(key: NavigationKey) {
     execute(NavigationOperation.CompleteFrom(instance, key.asInstance()))
 }
@@ -57,22 +157,56 @@ public fun <R : Any> NavigationHandle<NavigationKey.WithResult<R>>.completeFrom(
     error("${instance.key} is a NavigationKey.WithResult and cannot complete from a NavigationKey that does not have a result")
 }
 
+/**
+ * Type-safe [completeFrom] for result destinations: forwards completion
+ * to [key], which must produce a result of the same type [R] this handle
+ * is expecting. The compiler rejects mismatched result types.
+ */
 public fun <R : Any> NavigationHandle<NavigationKey.WithResult<R>>.completeFrom(key: NavigationKey.WithResult<R>) {
     execute(NavigationOperation.CompleteFrom(instance, key.asInstance()))
 }
 
+/**
+ * [completeFrom] variant that accepts a [NavigationKey.WithMetadata]
+ * wrapper around the forwarded key — use this when the destination you
+ * want to forward to was built with extra metadata (e.g. result-channel
+ * routing data attached via `withMetadata { … }`).
+ */
 public fun <R : Any> NavigationHandle<NavigationKey.WithResult<R>>.completeFrom(key: NavigationKey.WithMetadata<NavigationKey.WithResult<R>>) {
     execute(NavigationOperation.CompleteFrom(instance, key.asInstance()))
 }
 
+/**
+ * Pushes a new destination for [key] on top of the current backstack.
+ *
+ * Doesn't close the calling destination — both stay on the stack. Use
+ * [closeAndReplaceWith] when you want the new destination to take this
+ * one's place.
+ */
 public fun NavigationHandle<*>.open(key: NavigationKey) {
     execute(NavigationOperation.Open(key.asInstance()))
 }
 
+/**
+ * [open] variant that accepts a [NavigationKey.WithMetadata] wrapper —
+ * use this when the destination needs metadata attached (e.g. a result
+ * channel id from `registerForNavigationResult`, or transition overrides).
+ */
 public fun NavigationHandle<*>.open(key: NavigationKey.WithMetadata<*>) {
     execute(NavigationOperation.Open(key.asInstance()))
 }
 
+/**
+ * Closes this destination and opens [key] in one atomic operation — the
+ * backstack transitions directly from `[…, this]` to `[…, key]` with no
+ * intermediate state.
+ *
+ * Equivalent to a `close()` followed by an `open(key)` from the previous
+ * destination's perspective, but bundled so that interceptors,
+ * animations, and saved-state cleanup all see it as a single operation.
+ * Prefer this over manual `close(); open(key)` when you want a clean
+ * "replace this screen with that one" effect.
+ */
 public fun NavigationHandle<*>.closeAndReplaceWith(key: NavigationKey) {
     execute(
         NavigationOperation.AggregateOperation(
@@ -82,6 +216,10 @@ public fun NavigationHandle<*>.closeAndReplaceWith(key: NavigationKey) {
     )
 }
 
+/**
+ * [closeAndReplaceWith] variant accepting a [NavigationKey.WithMetadata]
+ * wrapper for the replacement key.
+ */
 public fun NavigationHandle<*>.closeAndReplaceWith(key: NavigationKey.WithMetadata<*>) {
     execute(
         NavigationOperation.AggregateOperation(
@@ -91,6 +229,15 @@ public fun NavigationHandle<*>.closeAndReplaceWith(key: NavigationKey.WithMetada
     )
 }
 
+/**
+ * Closes this destination AND forwards completion to [key] atomically.
+ *
+ * Compared to [completeFrom], this one also removes the current
+ * destination from the backstack immediately — useful when you don't want
+ * the intermediary to stay visible underneath while the forwarded
+ * destination is open. Common shape: a "choose flavour" screen
+ * closes-and-completes-from the variant-specific result destination.
+ */
 public fun NavigationHandle<NavigationKey>.closeAndCompleteFrom(key: NavigationKey) {
     execute(
         NavigationOperation.AggregateOperation(
@@ -109,6 +256,10 @@ public fun <R : Any> NavigationHandle<NavigationKey.WithResult<R>>.closeAndCompl
     error("${instance.key} is a NavigationKey.WithResult and cannot complete from a NavigationKey that does not have a result")
 }
 
+/**
+ * Type-safe [closeAndCompleteFrom] for result destinations: [key] must
+ * produce a result of the same type [R] this handle is expecting.
+ */
 public fun <R : Any> NavigationHandle<NavigationKey.WithResult<R>>.closeAndCompleteFrom(
     key: NavigationKey.WithResult<R>,
 ) {
@@ -120,6 +271,10 @@ public fun <R : Any> NavigationHandle<NavigationKey.WithResult<R>>.closeAndCompl
     )
 }
 
+/**
+ * [closeAndCompleteFrom] variant that accepts a [NavigationKey.WithMetadata]
+ * wrapper around the forwarded key.
+ */
 public fun <R : Any> NavigationHandle<NavigationKey.WithResult<R>>.closeAndCompleteFrom(
     key: NavigationKey.WithMetadata<NavigationKey.WithResult<R>>,
 ) {

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/NavigationHandle.ui.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/NavigationHandle.ui.kt
@@ -8,17 +8,44 @@ import dev.enro.ui.LocalNavigationContext
 import kotlin.jvm.JvmName
 import kotlin.reflect.KClass
 
+/**
+ * Returns the [NavigationHandle] for the destination this Composable is
+ * rendering in. Untyped — the handle is `NavigationHandle<NavigationKey>`,
+ * so the key type is whatever the destination was opened with.
+ *
+ * Prefer the reified `navigationHandle<MyKey>()` overload when you know
+ * the key type, to avoid casting and to surface mismatches at compile
+ * time.
+ *
+ * Throws if called outside a destination composition (i.e. outside the
+ * Composable lambda passed to `navigationDestination<…>`).
+ */
 @JvmName("untypedNavigationHandle")
 @Composable
 public fun navigationHandle(): NavigationHandle<NavigationKey> {
     return navigationHandle<NavigationKey>()
 }
 
+/**
+ * Returns the [NavigationHandle] typed to [T] for the destination this
+ * Composable is rendering in. Verifies at runtime that the destination's
+ * key really is a [T] and throws a descriptive error otherwise — usually
+ * a sign the function was called from the wrong destination.
+ *
+ * The typed handle gives you access to the result-aware overloads of
+ * [complete] / [completeFrom] / [closeAndCompleteFrom] when [T] extends
+ * [NavigationKey.WithResult].
+ */
 @Composable
 public inline fun <reified T: NavigationKey> navigationHandle(): NavigationHandle<T> {
     return navigationHandle(T::class)
 }
 
+/**
+ * Explicit-[KClass] variant of `navigationHandle<T>()` for the rare case
+ * you can't use a reified type parameter (e.g. dynamically chosen key
+ * type, Java interop).
+ */
 @Composable
 public fun <T: NavigationKey> navigationHandle(
     keyType: KClass<T>,
@@ -36,6 +63,17 @@ public fun <T: NavigationKey> navigationHandle(
     return navigationHandle
 }
 
+/**
+ * Applies a [NavigationHandleConfiguration] block to this handle for the
+ * lifetime of the surrounding composition. Registrations made inside
+ * [block] (e.g. `onCloseRequested { … }`) are torn down automatically
+ * when the Composable leaves composition.
+ *
+ * Backed by a [DisposableEffect] keyed on [block], so changing the block
+ * identity tears down the previous configuration and re-runs the new one.
+ * For a `ViewModel`-scoped lifetime, use the `config` parameter on the
+ * `ViewModel.navigationHandle` delegated property instead.
+ */
 @Composable
 public inline fun <reified T: NavigationKey> NavigationHandle<T>.configure(
     noinline block: NavigationHandleConfiguration<T>.() -> Unit

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/NavigationHandle.viewmodel.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/NavigationHandle.viewmodel.kt
@@ -6,6 +6,27 @@ import dev.enro.viewmodel.navigationHandleReference
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KClass
 
+/**
+ * Delegated property that exposes this ViewModel's [NavigationHandle]
+ * typed to [K], with an optional [config] block for lifetime-scoped
+ * configuration (e.g. registering an `onCloseRequested` callback).
+ *
+ * Standard usage:
+ * ```
+ * class MyViewModel : ViewModel() {
+ *     val navigation by navigationHandle<MyKey> {
+ *         onCloseRequested {
+ *             // ask the user before closing
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * If [K] doesn't match the destination's actual key type, the property
+ * throws on first access with a clear message — usually a sign the wrong
+ * ViewModel was wired to the destination. Configuration registered via
+ * [config] is torn down when the ViewModel itself is cleared.
+ */
 public inline fun <reified K : NavigationKey> ViewModel.navigationHandle(
     noinline config: (NavigationHandleConfiguration<K>.() -> Unit)? = null,
 ): ReadOnlyProperty<ViewModel, NavigationHandle<K>> {
@@ -15,6 +36,10 @@ public inline fun <reified K : NavigationKey> ViewModel.navigationHandle(
     )
 }
 
+/**
+ * Explicit-[KClass] form of `ViewModel.navigationHandle<K>(config)` for
+ * cases where you can't use a reified type parameter.
+ */
 public fun <K : NavigationKey> ViewModel.navigationHandle(
     keyType: KClass<K>,
     config: (NavigationHandleConfiguration<K>.() -> Unit)? = null,
@@ -35,11 +60,20 @@ public fun <K : NavigationKey> ViewModel.navigationHandle(
     return ReadOnlyProperty { _, _ -> navigationHandle as NavigationHandle<K> }
 }
 
+/**
+ * Delegated property that exposes this ViewModel's [NavigationHandle]
+ * typed to [K], with no extra configuration. Use the `(config)` overload
+ * when you need to register lifetime-scoped behaviour.
+ */
 public inline fun <reified K : NavigationKey> ViewModel.navigationHandle(): ReadOnlyProperty<ViewModel, NavigationHandle<K>> {
    return navigationHandle(
        config = null,
    )
 }
+
+/**
+ * Explicit-[KClass] form of `ViewModel.navigationHandle<K>()`.
+ */
 public fun <K : NavigationKey> ViewModel.navigationHandle(
     keyType: KClass<K>,
 ): ReadOnlyProperty<ViewModel, NavigationHandle<K>> {
@@ -49,6 +83,17 @@ public fun <K : NavigationKey> ViewModel.navigationHandle(
     )
 }
 
+/**
+ * Returns the untyped [NavigationHandle] attached to this ViewModel.
+ *
+ * Lower-level than the `navigationHandle()` delegated property — use this
+ * when you need the handle outside a property declaration (e.g. inside a
+ * helper that takes the ViewModel as a parameter). Most destination code
+ * should use `by navigationHandle<MyKey>()` instead.
+ *
+ * Throws if the ViewModel wasn't created with a navigation handle bound
+ * to it (i.e. wasn't constructed via the destination's ViewModel factory).
+ */
 public fun ViewModel.getNavigationHandle(): NavigationHandle<NavigationKey> {
     val reference = navigationHandleReference
     if (reference.navigationHandle == null) {

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/NavigationHandleConfiguration.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/NavigationHandleConfiguration.kt
@@ -8,12 +8,47 @@ import dev.enro.interceptor.builder.navigationInterceptor
 
 private typealias OnCloseCallback<T> = NavigationHandle<T>.() -> Unit
 
+/**
+ * Scope for configuring lifecycle-aware behaviour on a [NavigationHandle].
+ *
+ * Obtain one of these via `NavigationHandle.configure { … }` inside a
+ * Composable or via the `config` lambda on the `ViewModel.navigationHandle`
+ * delegated property. The configuration's lifetime is tied to the call
+ * site:
+ *
+ * - In a Composable, `configure` wraps a [androidx.compose.runtime.DisposableEffect],
+ *   so the registrations are torn down when the composable leaves
+ *   composition.
+ * - In a `ViewModel`, the configuration is attached to the ViewModel's
+ *   `addCloseable`, so it lives as long as the ViewModel does.
+ *
+ * Registrations made in this scope (currently only [onCloseRequested]) are
+ * automatically removed when the configuration is closed — you can
+ * register without worrying about manual cleanup.
+ */
 public class NavigationHandleConfiguration<T : NavigationKey>(
     private val navigation: NavigationHandle<T>,
 ) {
     private val closeables: MutableList<AutoCloseable> = mutableListOf()
 
-    // TODO: Add documentation here
+    /**
+     * Registers [callback] to run when something asks the destination to
+     * close via [requestClose] (system back gesture, predictive back,
+     * "X" affordances calling `requestClose`).
+     *
+     * Use this to insert pre-close work — a confirmation dialog, a "save
+     * draft?" prompt, an unsaved-changes guard. Inside the callback, call
+     * [close] yourself when you actually want the destination to close;
+     * if you don't, the destination stays.
+     *
+     * Only one callback may be active per handle at a time — registering a
+     * second while the first is still in scope throws at the moment the
+     * close is requested. Register in exactly one place per destination
+     * (typically the ViewModel; otherwise the top-level Composable).
+     *
+     * The registration is removed automatically when the surrounding
+     * configuration is disposed, so you don't need to unregister manually.
+     */
     public fun onCloseRequested(
         callback: OnCloseCallback<T>,
     ) {

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/context/NavigationContext.getNavigationHandle.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/context/NavigationContext.getNavigationHandle.kt
@@ -6,10 +6,25 @@ import dev.enro.NavigationKey
 import dev.enro.viewmodel.getNavigationHandle
 import kotlin.jvm.JvmName
 
+/**
+ * Returns the [NavigationHandle] typed to [T] for this navigation
+ * context, validating the key type at runtime.
+ *
+ * Most consumers should reach for the Composable / ViewModel accessors
+ * instead. This is the right call when you're walking the navigation
+ * context tree (e.g. inside a `NavigationContainer` traversal or a custom
+ * back handler that inspects child contexts) and need a handle for a
+ * specific child.
+ */
 public inline fun <reified T : NavigationKey> AnyNavigationContext.getNavigationHandle(): NavigationHandle<T> {
     return (this as ViewModelStoreOwner).getNavigationHandle<T>()
 }
 
+/**
+ * Untyped variant of [getNavigationHandle] for code that needs to reach
+ * the handle but doesn't care (or can't tell) what the destination's key
+ * type is.
+ */
 @JvmName("getNavigationHandleDefault")
 public fun AnyNavigationContext.getNavigationHandle(): NavigationHandle<NavigationKey> {
     return (this as ViewModelStoreOwner).getNavigationHandle<NavigationKey>()

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/path/NavigationHandle.getNavigationKeyFromPath.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/path/NavigationHandle.getNavigationKeyFromPath.kt
@@ -5,6 +5,20 @@ import dev.enro.NavigationHandle
 import dev.enro.NavigationKey
 import dev.enro.annotations.ExperimentalEnroApi
 
+/**
+ * Resolves [path] against the controller's registered `@NavigationPath`
+ * bindings and returns the matching [NavigationKey], or `null` if no
+ * binding matches.
+ *
+ * Use this when a destination needs to react to an external URL /
+ * deep-link string — e.g. when handling a clicked notification, a
+ * `data:` intent, or a web-routed message. The resolved key can be
+ * handed to [open] / [closeAndReplaceWith] like any other key.
+ *
+ * The handle receiver scopes the lookup to the currently-installed
+ * [EnroController]; if you're outside a destination, use the controller
+ * extensions directly.
+ */
 @ExperimentalEnroApi
 public fun NavigationHandle<*>.getNavigationKeyFromPath(
     path: String,

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/path/NavigationHandle.getPathFromNavigationKey.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/path/NavigationHandle.getPathFromNavigationKey.kt
@@ -5,6 +5,15 @@ import dev.enro.NavigationHandle
 import dev.enro.NavigationKey
 import dev.enro.annotations.ExperimentalEnroApi
 
+/**
+ * Reverse of [getNavigationKeyFromPath]: serialises [key] back to its
+ * registered path string, or returns `null` if [key]'s type has no
+ * `@NavigationPath` binding registered on the controller.
+ *
+ * Use this when you need to emit a URL for the current navigation state
+ * — e.g. to update the browser URL bar, build a share link, or persist a
+ * deep-link target.
+ */
 @ExperimentalEnroApi
 public fun NavigationHandle<*>.getPathFromNavigationKey(
     key: NavigationKey,

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/result/flow/NavigationFlowReference.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/result/flow/NavigationFlowReference.kt
@@ -21,6 +21,16 @@ public class NavigationFlowReference internal constructor(
     internal object MetadataKey : NavigationKey.TransientMetadataKey<NavigationFlow<*>?>(null)
 }
 
+/**
+ * Resolves [reference] back to the live [NavigationFlow] from this
+ * destination's metadata. The reference is the serialisation-safe handle
+ * you pass into a destination's [NavigationKey] when you want that
+ * destination to be able to call back into the flow (e.g. to jump back
+ * to an earlier step for editing).
+ *
+ * Throws if the destination wasn't opened as part of a flow, or if the
+ * reference's id doesn't match the attached flow.
+ */
 @ExperimentalEnroApi
 public fun NavigationHandle<*>.getNavigationFlow(reference: NavigationFlowReference): NavigationFlow<*> {
     val flow = instance.metadata.get(NavigationFlowReference.MetadataKey)

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/result/flow/NavigationHandle.navigationFlow.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/result/flow/NavigationHandle.navigationFlow.kt
@@ -3,6 +3,16 @@ package dev.enro.result.flow
 import dev.enro.NavigationHandle
 import dev.enro.annotations.AdvancedEnroApi
 
+/**
+ * The [NavigationFlow] that owns this destination's entry, if the
+ * destination was opened as part of one — or `null` if the destination
+ * is running outside of any flow.
+ *
+ * Advanced surface: most flow consumers should reach for the typed
+ * accessors on `NavigationFlowScope` instead. Use this only when you
+ * need to introspect the flow metadata from outside the flow's own
+ * scope (e.g. a custom interceptor / plugin).
+ */
 @AdvancedEnroApi
 public val NavigationHandle<*>.navigationFlow: NavigationFlow<*>?
     get() {

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/viewmodel/ViewModelStoreOwner.getNavigationHandle.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/viewmodel/ViewModelStoreOwner.getNavigationHandle.kt
@@ -6,10 +6,26 @@ import dev.enro.NavigationKey
 import dev.enro.handle.getNavigationHandleHolder
 import kotlin.reflect.KClass
 
+/**
+ * Returns the [NavigationHandle] typed to [K] for the destination whose
+ * `ViewModelStore` this owner exposes.
+ *
+ * Intended for Android-side glue (Activity, Fragment, custom hosts) that
+ * needs to reach the handle for a destination it owns. Inside the
+ * destination's Composable or ViewModel, prefer `navigationHandle<K>()`
+ * (composable) or `by navigationHandle<K>()` (ViewModel) — those are the
+ * standard accessors.
+ *
+ * Throws if no Enro handle is associated with this owner, or if [K]
+ * doesn't match the destination's actual key type.
+ */
 public inline fun <reified K: NavigationKey> ViewModelStoreOwner.getNavigationHandle(): NavigationHandle<K> {
     return getNavigationHandle(K::class)
 }
 
+/**
+ * Explicit-[KClass] form of `ViewModelStoreOwner.getNavigationHandle<K>()`.
+ */
 public fun <K: NavigationKey> ViewModelStoreOwner.getNavigationHandle(
     keyType: KClass<K>,
 ): NavigationHandle<K> {

--- a/enro-test/README.md
+++ b/enro-test/README.md
@@ -1,0 +1,56 @@
+# `enro-test`
+
+Test helpers for Enro destinations and the runtime as a whole. Lets you
+exercise navigation behaviour from a unit test — without spinning up an
+Android instrumentation harness — by installing a controllable
+`EnroController` for the duration of the test and exposing assertion
+helpers around handles, backstacks, paths, operations, and synthetic
+destinations.
+
+Targets the same set as `enro-runtime` (Android, iOS, JVM Desktop,
+WASM JS), so multiplatform code can be tested on any host the runtime
+supports.
+
+## What's in here
+
+- **`runEnroTest { … }`** — installs an isolated controller per test
+  and tears it down afterwards. Use this as the outer wrapper for any
+  test that needs the runtime.
+- **`TestNavigationHandle`** — a handle implementation that records
+  every operation executed against it. Combine with `createTestNavigationHandle(key)`
+  for tests of destination logic that doesn't need the full backstack.
+- **Backstack / path / operation assertions** — `assertBackstackKeys`,
+  `assertBackstackSize`, `assertBackstackContains<T>`, `assertPathResolvesTo<T>`,
+  `assertOperationSequence(*KClass)`, `lastOperationOfType<T>()`.
+- **Synthetic destination tester** — `testSyntheticDestination(key)` /
+  `testSyntheticDestination(key, provider)` plus an outcome DSL
+  (`assertOpens<T>`, `assertCompletesFrom<T>`, `assertCloses`,
+  `assertCompletes`, `assertSideEffect`). Lets you unit-test a synthetic's
+  decision without rendering it.
+- **Fixtures** — `NavigationContextFixtures`, `NavigationContainerFixtures`,
+  `NavigationKeyFixtures` for building the bits of state a test needs.
+- **`installNavigationModule(module)` / `installPathBindings(vararg)`**
+  — one-line shortcuts for registering destinations or path bindings on
+  the test controller.
+
+## Typical usage
+
+```kotlin
+dependencies {
+    testImplementation("dev.enro:enro-test:3.0.0-alpha10")
+}
+```
+
+```kotlin
+@Test
+fun `profile button opens profile destination`() = runEnroTest {
+    val handle = createTestNavigationHandle(HomeKey)
+    HomeViewModel(handle).onProfileClicked()
+
+    handle.assertOpened<ProfileKey> { it.key.userId == "user-123" }
+}
+```
+
+For end-to-end Compose tests of `NavigationDisplay` and friends, pair
+this module with `androidx.compose.ui:ui-test` and `runComposeUiTest`
+— see `enro-runtime`'s `SceneIntegrationTests` for examples.

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,3 +20,9 @@ kapt.incremental.apt=true
 kotlin.incremental.wasm=false
 
 ksp.incremental=true
+
+# Required by Vanniktech maven-publish 0.36.0 (which needs Dokka v2 mode
+# for -javadoc.jar generation). Migrate fully to V2Enabled once the
+# DSL surface in ConfigurePublishing.kt is updated to match V2's API.
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -11,6 +11,7 @@ maven-publish = "0.36.0"
 ksp = "2.3.3"
 kotlinx-coroutines = "1.10.2"
 kotlin-js = "2026.5.0" # https://central.sonatype.com/artifact/org.jetbrains.kotlin-wrappers/kotlin-js
+dokka = "2.0.0"
 
 [libraries]
 android-gradle = { module = "com.android.tools.build:gradle", version.ref = "agp" }
@@ -19,6 +20,7 @@ kotlin-serialization-gradle = { module = "org.jetbrains.kotlin.plugin.serializat
 compose-compiler-gradle = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }
 compose-gradle = { module = "org.jetbrains.compose:org.jetbrains.compose.gradle.plugin", version.ref = "compose-plugin" }
 maven-publish-gradle = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "maven-publish" }
+dokka-gradle = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 
 emulator-wtf-gradle = "wtf.emulator:gradle-plugin:1.5.4"
 


### PR DESCRIPTION
## Summary

Closes out the four remaining items from the post-web-routing roadmap's DX tier. One commit per item, each independently reviewable.

### 1. NavigationHandle KDoc — `78edac8a`

The most-touched API in the library shipped with zero KDoc on the abstract class and all ~20 extensions / accessors. Hover-doc and the forthcoming Dokka site were both blank.

Covered: the `NavigationHandle` class itself + `instance` / `key` / `savedStateHandle` / `execute`, the close / requestClose pair, the complete / completeFrom / closeAndCompleteFrom families (including why the `WithResult` deprecated-error overloads exist), open / closeAndReplaceWith, `NavigationHandleConfiguration` + `onCloseRequested`, the four `navigationHandle()` accessors (composable, ViewModel delegate, ViewModelStoreOwner, AnyNavigationContext), `configure { }`, the path resolution helpers, and the flow metadata accessors.

### 2. Module READMEs — `725932ec`

`enro-runtime`, `enro-test`, `enro-processor`, `enro-annotations` had no module-level READMEs (only `enro-common` did). Added READMEs matching `enro-common`'s shape: one paragraph on the module's role, a "what's in here" bullet list of the core types/helpers, and a typical-usage snippet pointing back to the `dev.enro:enro` meta-artefact for normal consumers.

The `enro-test` README cross-references the helpers landing on `synthetic-testing-api` (PR #214). Those references are accurate against the post-merge state — see the **Merge order** note below.

### 3. `@NavigationPath` user guide — `329658b5`

New `docs/ghpages/docs/advanced/path-bindings.md`. Path bindings shipped across PRs #208 + #209 but the only doc was a half-page mention in `docs/platform/web.md`. The new page covers: the concept, simple property mapping, query parameters / optionals, value classes, `@NavigationPath.FromBinding` for hand-written bindings, the programmatic `createPathBinding` API, the runtime resolution functions on both sides, and the path-vs-state model (why nested-container destinations don't show up in the URL by design). Cross-links from / to the web platform docs, synthetic destinations page, and the deep-link recipes.

### 4. Dokka v2 setup — `9747010b`

Dokka was previously unconfigured — published artifacts shipped empty `-javadoc.jars` and there was no generated API reference site.

Wired up:
- Pinned Dokka 2.0.0; classpath on root + buildSrc.
- Enabled Dokka Gradle Plugin v2 via `gradle.properties` (required by vanniktech/maven-publish 0.36.0).
- Applied `org.jetbrains.dokka` inside `ConfigurePublishing` so every published module produces docs without per-module gradle changes.
- Multi-module aggregation: each published module is declared as a `dokka(project(...))` dependency at the root, so `./gradlew dokkaGenerate` produces a combined HTML site at `build/dokka/html/index.html`.

Verified:
- `./gradlew dokkaGenerate` produces the multi-module site; each module also has its own at `<module>/build/dokka/html/`.
- Full test suite (`:enro-runtime:desktopTest` + compat compile + wasmJs compile) still green after the plugin change.
- Vanniktech now wires `dokkaJavadocJar` tasks per publication so published artifacts pick up the generated docs automatically.

Follow-ups (intentionally out of scope):
- Source links / external doc cross-links (Kotlin, AndroidX, Compose).
- CI workflow to publish the aggregate site to GitHub Pages alongside the mkdocs docs.
- Migrate `V2EnabledWithHelpers` → `V2Enabled` once the convention plugin DSL is updated to the pure V2 API.

## Merge order

This branch was opened against the same `main` as PR #214 (synthetic-testing-api). The `enro-test` README references helpers from PR #214; **merge #214 first**, then this branch. If they go in the other order, the `enro-test` README has dangling references for one commit until #214 lands.

## Test plan

- [ ] `./gradlew :enro-runtime:desktopTest` — full suite still green after the KDoc changes (KDoc is comment-only, so this is just a smoke test).
- [ ] `./gradlew :enro-compat:compileDebugKotlinAndroid` — compat still compiles.
- [ ] `./gradlew :enro-runtime:compileKotlinWasmJs` — wasmJs still compiles.
- [ ] `./gradlew dokkaGenerate` — multi-module API reference site lands at `build/dokka/html/index.html`; each published module also has its own at `<module>/build/dokka/html/index.html`.
- [ ] Spot-check `build/dokka/html/index.html` in a browser — the new NavigationHandle KDoc shows up as actual prose, not bare signatures.
- [ ] Spot-check the docs render: `docs/advanced/path-bindings.md` shows up under Advanced Topics with the correct nav_order (7).
- [ ] Each new module README is rendered correctly on GitHub (relative links to `src/`, code blocks, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)