### PR TITLE
Suppress Escape→back in EnroBrowserContent by default

### DIFF
--- a/enro-runtime/src/wasmJsMain/kotlin/dev/enro/ui/EnroBrowserContent.kt
+++ b/enro-runtime/src/wasmJsMain/kotlin/dev/enro/ui/EnroBrowserContent.kt
@@ -1,10 +1,18 @@
 package dev.enro.ui
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
@@ -39,10 +47,18 @@ import kotlin.uuid.Uuid
  * }
  * ```
  *
+ * @param suppressEscapeAsBack When `true` (the default), pressing the
+ *   Escape key inside the Compose composition is consumed before
+ *   Compose Multiplatform's built-in `BackNavigationEventInput` can
+ *   translate it into a back-navigation event. Browser back/forward via
+ *   the history API is unaffected (it routes through `popstate`, not the
+ *   navigation event dispatcher). Set to `false` if your app deliberately
+ *   wants Escape→back behaviour.
  * @param content The composable content of your application
  */
 @Composable
 public fun EnroBrowserContent(
+    suppressEscapeAsBack: Boolean = true,
     content: @Composable EnroBrowserScope.() -> Unit,
 ) {
     val instance = remember { GenericBrowserKey.asInstance() }
@@ -105,7 +121,24 @@ public fun EnroBrowserContent(
         LocalNavigationHandle provides navigationHandle,
         LocalViewModelStoreOwner provides viewModelStoreOwner,
     ) {
-        browserScope.content()
+        if (suppressEscapeAsBack) {
+            // Consumes Escape KeyDown via Compose's preview key chain
+            // (outer → inner) before Compose Multiplatform's
+            // BackNavigationEventInput can translate it into a back event.
+            // Inner Popups/Dialogs run in their own focus tree and still
+            // see Escape — only the main composition's Escape is swallowed.
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .onPreviewKeyEvent { event ->
+                        event.type == KeyEventType.KeyDown && event.key == Key.Escape
+                    },
+            ) {
+                browserScope.content()
+            }
+        } else {
+            browserScope.content()
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Pressing Escape on the web target currently triggers a back-navigation. The binding lives in Compose Multiplatform itself: `BackNavigationEventInput.onKeyEvent` in `ui-wasm-js`'s `ComposeWindow.w3c.kt` translates Escape KeyDown into a back event that fires through the `NavigationEventDispatcher`. Browser back/forward goes through a different path (`popstate` → `WebHistoryPlugin`) and is unaffected.

For most apps that wasn't what the user wanted — Escape on a form field would silently navigate them back. Wrapping `EnroBrowserContent`'s content in a Box with `Modifier.onPreviewKeyEvent` consumes Escape KeyDown via Compose's preview key chain (outer → inner) before the platform's `BackNavigationEventInput` can react.

## API

New opt-out parameter: `EnroBrowserContent(suppressEscapeAsBack = false) { … }` for apps that genuinely want Escape→back behaviour. Default is `true`, so existing apps pick this up on the next bump without touching their entry point.

## What's not affected

- **Browser back / forward**: still routes through `popstate` and `WebHistoryPlugin` — unchanged.
- **Popup / Dialog Escape-to-dismiss**: popups run in their own focus tree, so their built-in Escape handling still works.

## Test plan

- [ ] `./gradlew :enro-runtime:compileKotlinWasmJs` — wasmJs compiles.
- [ ] `./gradlew :enro-runtime:desktopTest` — full suite green.
- [ ] Manual: run the recipes web app (`./gradlew :recipes:wasmJsBrowserDevelopmentRun`), open a non-root destination, press Escape — nothing happens (was: navigates back).
- [ ] Manual: click browser back — still navigates back as expected.
- [ ] Manual: open a Material3 `AlertDialog`, press Escape — dialog dismisses (popup focus tree is independent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)