### PR TITLE
Fix Kotlin/JS publish: expect/actual for MetadataKey identifier

### DIFF
--- a/enro-common/src/androidMain/kotlin/dev/enro/metadataKeyName.android.kt
+++ b/enro-common/src/androidMain/kotlin/dev/enro/metadataKeyName.android.kt
@@ -1,0 +1,9 @@
+package dev.enro
+
+import kotlin.reflect.KClass
+
+internal actual fun metadataKeyName(kClass: KClass<*>): String {
+    return kClass.qualifiedName
+        ?: kClass.simpleName
+        ?: error("MetadataKey class must have a qualifiedName or simpleName")
+}

--- a/enro-common/src/commonMain/kotlin/dev/enro/NavigationKey.kt
+++ b/enro-common/src/commonMain/kotlin/dev/enro/NavigationKey.kt
@@ -224,7 +224,7 @@ public interface NavigationKey {
         public val default: T,
     ) {
         public val name: String by lazy {
-            this::class.qualifiedName ?: error("MetadataKeys must have a valid qualifiedName")
+            metadataKeyName(this::class)
         }
     }
 

--- a/enro-common/src/commonMain/kotlin/dev/enro/metadataKeyName.kt
+++ b/enro-common/src/commonMain/kotlin/dev/enro/metadataKeyName.kt
@@ -1,0 +1,21 @@
+package dev.enro
+
+import kotlin.reflect.KClass
+
+/**
+ * Stable string identifier for a [NavigationKey.MetadataKey]'s class.
+ * Used as the storage key inside [NavigationKey.Metadata] and persisted
+ * across saved-state round-trips, so the identifier must be:
+ *
+ * - **Stable across runs** — serialised metadata must restore to the
+ *   same logical key on next launch.
+ * - **Unique per MetadataKey class** — two different MetadataKey objects
+ *   must not collide.
+ *
+ * On every target except Kotlin/JS this is `KClass.qualifiedName`. On
+ * Kotlin/JS, `qualifiedName` is unsupported by the Kotlin reflection
+ * API, so we fall back to `simpleName`. The JS fallback is correct for
+ * the common `object MyKey : MetadataKey<...>` pattern as long as the
+ * `MyKey` simple names are unique within the app.
+ */
+internal expect fun metadataKeyName(kClass: KClass<*>): String

--- a/enro-common/src/desktopMain/kotlin/dev/enro/metadataKeyName.desktop.kt
+++ b/enro-common/src/desktopMain/kotlin/dev/enro/metadataKeyName.desktop.kt
@@ -1,0 +1,9 @@
+package dev.enro
+
+import kotlin.reflect.KClass
+
+internal actual fun metadataKeyName(kClass: KClass<*>): String {
+    return kClass.qualifiedName
+        ?: kClass.simpleName
+        ?: error("MetadataKey class must have a qualifiedName or simpleName")
+}

--- a/enro-common/src/iosMain/kotlin/dev/enro/metadataKeyName.ios.kt
+++ b/enro-common/src/iosMain/kotlin/dev/enro/metadataKeyName.ios.kt
@@ -1,0 +1,9 @@
+package dev.enro
+
+import kotlin.reflect.KClass
+
+internal actual fun metadataKeyName(kClass: KClass<*>): String {
+    return kClass.qualifiedName
+        ?: kClass.simpleName
+        ?: error("MetadataKey class must have a qualifiedName or simpleName")
+}

--- a/enro-common/src/jsMain/kotlin/dev/enro/metadataKeyName.js.kt
+++ b/enro-common/src/jsMain/kotlin/dev/enro/metadataKeyName.js.kt
@@ -1,0 +1,12 @@
+package dev.enro
+
+import kotlin.reflect.KClass
+
+// Kotlin/JS reflection does not expose qualifiedName. simpleName is the
+// only stable identifier available — collisions across packages are
+// possible in principle, but the recommended `object MyKey : MetadataKey<…>`
+// pattern produces a unique simpleName per definition site.
+internal actual fun metadataKeyName(kClass: KClass<*>): String {
+    return kClass.simpleName
+        ?: error("MetadataKey class must have a simpleName on Kotlin/JS")
+}

--- a/enro-common/src/wasmJsMain/kotlin/dev/enro/metadataKeyName.wasmJs.kt
+++ b/enro-common/src/wasmJsMain/kotlin/dev/enro/metadataKeyName.wasmJs.kt
@@ -1,0 +1,9 @@
+package dev.enro
+
+import kotlin.reflect.KClass
+
+internal actual fun metadataKeyName(kClass: KClass<*>): String {
+    return kClass.qualifiedName
+        ?: kClass.simpleName
+        ?: error("MetadataKey class must have a qualifiedName or simpleName")
+}


### PR DESCRIPTION
## Summary

`./gradlew publishToMavenLocal` was failing with:

```
e: …/enro-common/src/commonMain/kotlin/dev/enro/NavigationKey.kt:227:25
This reflection API is not supported in Kotlin/JS.
```

`enro-common` targets Kotlin/JS (so a NodeJS backend can reference `NavigationKey` types) but the inner `MetadataKey.name` was using `this::class.qualifiedName`, which K/JS refuses at compile time. The code happened to compile on every other target so this only surfaced at publish.

## Fix

Internal `expect fun metadataKeyName(kClass)` in commonMain, with actuals per source set:

| Source set | Implementation |
|---|---|
| `androidMain` / `desktopMain` / `iosMain` / `wasmJsMain` | `qualifiedName` (with a defensive `simpleName` fallback) |
| `jsMain` | `simpleName` only — with a doc comment explaining the cross-package collision risk and why the `object MyKey : MetadataKey<…>` pattern stays safe |

## Verified

- `./gradlew :enro-common:publishToMavenLocal` — succeeds across all five targets (was: failing on JS compile)
- `./gradlew :enro-common:compileKotlinJs` / `compileKotlinDesktop` / `compileKotlinIosSimulatorArm64` / `compileKotlinWasmJs` — all green
- `./gradlew :enro-runtime:desktopTest` — full suite still green

## Test plan

- [ ] `./gradlew :enro-common:publishToMavenLocal` — JS target compiles and publishes.
- [ ] `./gradlew publishToMavenLocal` (full project) — confirm the original beta-publish-prep run finishes without the K/JS error.
- [ ] Spot-check generated POM in `~/.m2/repository/dev/enro/enro-common/3.0.0-beta01/` — looks normal, includes the JS variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)