### PR TITLE
Reseed a cleared NavigationHandleHolder after pop

### DIFF
--- a/enro-runtime/src/commonMain/kotlin/dev/enro/handle/NavigationHandleHolder.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/handle/NavigationHandleHolder.kt
@@ -53,6 +53,24 @@ internal class NavigationHandleHolder<T : NavigationKey>(
             EnroLog.warn("NavigationHandle with instance $instance has been cleared, but has received an operation which will be ignored")
         }
     }
+
+    internal companion object {
+        /**
+         * Creates a holder whose handle is already cleared. Used to reseed a destination's
+         * ViewModelStore after it is cleared on pop, so that ViewModel creation racing
+         * destination teardown (e.g. a Dialog window whose composition initializes on window
+         * attach, after the destination was popped) receives a no-op NavigationHandle instead
+         * of failing the strict lookup in [getNavigationHandleHolder].
+         */
+        fun cleared(
+            instance: NavigationKey.Instance<*>,
+        ): NavigationHandleHolder<*> {
+            @Suppress("UNCHECKED_CAST")
+            return NavigationHandleHolder(
+                navigationHandle = ClearedNavigationHandle(instance as NavigationKey.Instance<NavigationKey>),
+            )
+        }
+    }
 }
 
 @PublishedApi

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/ui/decorators/navigationViewModelStoreDecorator.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/ui/decorators/navigationViewModelStoreDecorator.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.viewmodel.viewModelFactory
 import androidx.savedstate.SavedStateRegistryOwner
 import androidx.savedstate.compose.LocalSavedStateRegistryOwner
 import dev.enro.NavigationKey
+import dev.enro.handle.NavigationHandleHolder
 import dev.enro.ui.LocalNavigationContext
 
 /**
@@ -171,7 +172,20 @@ private class ViewModelStoreStorage : ViewModel() {
     }
 
     fun clearViewModelStoreForInstance(instance: NavigationKey.Instance<*>) {
-        stores.remove(instance.id)?.clear()
+        val store = stores.remove(instance.id) ?: return
+        store.clear()
+        // A destination's composition can outlive the pop that clears its ViewModelStore:
+        // a Dialog's content composes in a separate window composition that initializes
+        // asynchronously on window attach, so a destination popped in the same frame it was
+        // opened can still create ViewModels against this store. Reseed a cleared holder so
+        // that late creation receives a no-op NavigationHandle (which logs and ignores
+        // operations) instead of crashing the strict lookup in getNavigationHandleHolder.
+        ViewModelProvider.create(
+            store = store,
+            factory = viewModelFactory {
+                initializer { NavigationHandleHolder.cleared(instance) }
+            },
+        )[NavigationHandleHolder::class]
     }
 
     override fun onCleared() {


### PR DESCRIPTION
Reseed a cleared NavigationHandleHolder after a destination's store is cleared on pop

A destination's composition can outlive the pop that clears its ViewModelStore: a Dialog's content composes in a separate window composition that initializes asynchronously on window attach, so a destination popped in the same frame it was opened can still create ViewModels against the cleared store. ViewModel creation then hits the strict lookup in getNavigationHandleHolder, which errors with "Expected NavigationHandleHolder to be present in ViewModelStoreOwner ... but it was missing" and crashes the app (seen in production from a floatingCardDestination dialog racing teardown).

The cleared-handle semantics for late access already exist (ClearedNavigationHandle logs and ignores operations), but they only survive inside the holder object — clearing the store drops the holder itself. Reseed the cleared store with a holder carrying a ClearedNavigationHandle so late ViewModel creation gets the designed no-op behaviour instead of a crash. The strict error still fires for stores that never had a holder, which keeps genuine decorator-wiring bugs loud.