### PR TITLE
Reseed cleared NavigationHandleHolders when a parent's store storage is cleared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 ## Unreleased
 
-## 3.0.0-beta03 (2026-06-11)
+### Stability
+
+* Fixed a production crash (`IllegalStateException: No NavigationHandle found for …` /
+  `Expected NavigationHandleHolder to be present in ViewModelStoreOwner …`) that occurred
+  when a destination's content composed or recomposed after its ViewModelStore had been
+  cleared. This race is possible because Dialog windows and (on iOS) ModalBottomSheet
+  layers compose their content in a separate composition that initializes and tears down
+  asynchronously from the composition that drives navigation. A destination's cleared
+  store is now reseeded with a no-op `NavigationHandle` (which logs and ignores
+  operations), both when the destination itself is popped and when a parent destination's
+  store is cleared while children are still composing.
 
 ### Web browser history (WasmJS)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,7 +77,14 @@ subprojects {
             tasks.findByName("testAndroidHostTest")?.let { continuousIntegration.dependsOn(it) }
             tasks.findByName("desktopTest")?.let { continuousIntegration.dependsOn(it) }
             tasks.findByName("wasmJsBrowserTest")?.let { continuousIntegration.dependsOn(it) }
-            tasks.findByName("testWithEmulatorWtf")?.let { continuousIntegration.dependsOn(it) }
+            // emulator.wtf device tests need a valid EW_API_TOKEN. Fork PRs can't read
+            // repository secrets, so the token arrives empty there and the emulator.wtf
+            // plugin fails the whole build with "Http error 403: Invalid apiToken".
+            // Only wire the device tests into CI when a token is actually present
+            // (pushes to main and same-repo PRs); everything else still runs.
+            if (!System.getenv("EW_API_TOKEN").isNullOrBlank()) {
+                tasks.findByName("testWithEmulatorWtf")?.let { continuousIntegration.dependsOn(it) }
+            }
             // Compile-only fallbacks so modules without tests (e.g. recipes)
             // are still build-checked by CI. For modules with tests, these are
             // no-ops — the test tasks above already depend on compilation.

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/ui/decorators/navigationViewModelStoreDecorator.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/ui/decorators/navigationViewModelStoreDecorator.kt
@@ -165,33 +165,49 @@ private class DestinationViewModelStoreOwner(
  * This ViewModel is stored in the parent ViewModelStore and manages child stores.
  */
 private class ViewModelStoreStorage : ViewModel() {
-    private val stores = mutableMapOf<String, ViewModelStore>()
+    private val stores = mutableMapOf<String, StoreEntry>()
+
+    private class StoreEntry(
+        val instance: NavigationKey.Instance<*>,
+        val store: ViewModelStore,
+    )
 
     fun viewModelStoreForInstance(instance: NavigationKey.Instance<*>): ViewModelStore {
-        return stores.getOrPut(instance.id) { ViewModelStore() }
+        return stores.getOrPut(instance.id) { StoreEntry(instance, ViewModelStore()) }.store
     }
 
     fun clearViewModelStoreForInstance(instance: NavigationKey.Instance<*>) {
-        val store = stores.remove(instance.id) ?: return
-        store.clear()
-        // A destination's composition can outlive the pop that clears its ViewModelStore:
-        // a Dialog's content composes in a separate window composition that initializes
-        // asynchronously on window attach, so a destination popped in the same frame it was
-        // opened can still create ViewModels against this store. Reseed a cleared holder so
-        // that late creation receives a no-op NavigationHandle (which logs and ignores
-        // operations) instead of crashing the strict lookup in getNavigationHandleHolder.
-        ViewModelProvider.create(
-            store = store,
-            factory = viewModelFactory {
-                initializer { NavigationHandleHolder.cleared(instance) }
-            },
-        )[NavigationHandleHolder::class]
+        val entry = stores.remove(instance.id) ?: return
+        entry.store.clearAndReseedNavigationHandle(instance)
     }
 
     override fun onCleared() {
-        stores.forEach { (_, store) -> store.clear() }
+        stores.forEach { (_, entry) ->
+            entry.store.clearAndReseedNavigationHandle(entry.instance)
+        }
         stores.clear()
     }
+}
+
+/**
+ * A destination's composition can outlive the clear of its ViewModelStore:
+ * a Dialog's content (or a ModalBottomSheet's, on iOS) composes in a separate
+ * window/layer composition that initializes and tears down asynchronously, so a
+ * destination that is popped — or whose parent destination is popped, which clears
+ * every child store through [ViewModelStoreStorage.onCleared] — can still create
+ * ViewModels against this store for a frame. Reseed a cleared holder so that late
+ * creation receives a no-op NavigationHandle (which logs and ignores operations)
+ * instead of crashing the strict lookup in getNavigationHandleHolder or the
+ * `navigationHandle()` composable's "No NavigationHandle found" initializer.
+ */
+private fun ViewModelStore.clearAndReseedNavigationHandle(instance: NavigationKey.Instance<*>) {
+    clear()
+    ViewModelProvider.create(
+        store = this,
+        factory = viewModelFactory {
+            initializer { NavigationHandleHolder.cleared(instance) }
+        },
+    )[NavigationHandleHolder::class]
 }
 
 /**

--- a/enro-runtime/src/commonTest/kotlin/dev/enro/ViewModelStoreDecoratorTests.kt
+++ b/enro-runtime/src/commonTest/kotlin/dev/enro/ViewModelStoreDecoratorTests.kt
@@ -1,0 +1,180 @@
+package dev.enro
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import androidx.savedstate.savedState
+import dev.enro.handle.getNavigationHandleHolder
+import dev.enro.test.NavigationKeyFixtures
+import dev.enro.ui.NavigationDestination
+import dev.enro.ui.decorators.NavigationDestinationDecorator
+import dev.enro.ui.decorators.NavigationSavedStateHolder
+import dev.enro.ui.decorators.decorateNavigationDestination
+import dev.enro.ui.decorators.savedStateDecorator
+import dev.enro.ui.decorators.viewModelStoreDecorator
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the ViewModelStore decorator's clear-and-reseed behaviour.
+ *
+ * A destination's composition can outlive the clear of its ViewModelStore
+ * (Dialog windows and, on iOS, ModalBottomSheet layers compose in a separate
+ * composition that tears down asynchronously), so a cleared store must be
+ * reseeded with a cleared NavigationHandleHolder — otherwise a late
+ * `navigationHandle()` lookup fails its strict initializer and crashes.
+ *
+ * These tests drive the decorator directly, capture the destination-scoped
+ * [ViewModelStoreOwner] a racing composition would hold, and assert that the
+ * strict holder lookup still succeeds after each of the two clearing paths:
+ * the destination's own pop, and a parent store clear that tears down child
+ * stores through `ViewModelStoreStorage.onCleared`.
+ */
+@OptIn(ExperimentalTestApi::class)
+class ViewModelStoreDecoratorTests {
+
+    private class TrackingViewModel : ViewModel() {
+        var isCleared = false
+            private set
+
+        override fun onCleared() {
+            isCleared = true
+        }
+    }
+
+    private class Harness(
+        val parentStore: ViewModelStore,
+        val decorator: NavigationDestinationDecorator<NavigationKey>,
+        val instance: NavigationKey.Instance<NavigationKeyFixtures.SimpleKey>,
+        private val getDestinationOwner: () -> ViewModelStoreOwner?,
+        private val getTrackingViewModel: () -> TrackingViewModel?,
+    ) {
+        val destinationOwner: ViewModelStoreOwner
+            get() = assertNotNull(getDestinationOwner(), "destination content did not compose")
+
+        val trackingViewModel: TrackingViewModel
+            get() = assertNotNull(getTrackingViewModel(), "destination content did not compose")
+    }
+
+    /**
+     * Composes a destination wrapped in the savedState + viewModelStore
+     * decorators (savedState first, as the ViewModelStore decorator requires),
+     * creating a [TrackingViewModel] in the destination's store, and returns
+     * the pieces a test needs to exercise the clearing paths.
+     */
+    private fun androidx.compose.ui.test.ComposeUiTest.composeDestination(
+        isDestinationVisible: () -> Boolean = { true },
+    ): Harness {
+        val parentStore = ViewModelStore()
+        val parentOwner = object : ViewModelStoreOwner {
+            override val viewModelStore: ViewModelStore get() = parentStore
+        }
+        val decorator = viewModelStoreDecorator(
+            parentViewModelStoreOwner = parentOwner,
+            viewModelStore = parentStore,
+            shouldRemoveStoreOwner = { true },
+        )
+        val instance = NavigationKeyFixtures.SimpleKey().asInstance()
+
+        var destinationOwner: ViewModelStoreOwner? = null
+        var trackingViewModel: TrackingViewModel? = null
+
+        val destination = decorateNavigationDestination(
+            destination = NavigationDestination.createWithoutScope(instance = instance) {
+                val owner = checkNotNull(LocalViewModelStoreOwner.current)
+                destinationOwner = owner
+                trackingViewModel = ViewModelProvider.create(
+                    store = owner.viewModelStore,
+                    factory = viewModelFactory { initializer { TrackingViewModel() } },
+                )[TrackingViewModel::class]
+            },
+            decorators = listOf(
+                savedStateDecorator(NavigationSavedStateHolder(savedState())),
+                decorator,
+            ),
+        )
+
+        setContent {
+            if (isDestinationVisible()) {
+                destination.Content()
+            }
+        }
+        waitForIdle()
+
+        return Harness(
+            parentStore = parentStore,
+            decorator = decorator,
+            instance = instance,
+            getDestinationOwner = { destinationOwner },
+            getTrackingViewModel = { trackingViewModel },
+        )
+    }
+
+    @Test
+    fun `popping a destination clears its ViewModels and reseeds a cleared NavigationHandle`() = runComposeUiTest {
+        var isDestinationVisible by mutableStateOf(true)
+        val harness = composeDestination(isDestinationVisible = { isDestinationVisible })
+        val destinationOwner = harness.destinationOwner
+        val trackingViewModel = harness.trackingViewModel
+
+        // Leave composition before popping, mirroring the ordering the
+        // compositionTrackingDecorator produces for a real pop.
+        isDestinationVisible = false
+        waitForIdle()
+        harness.decorator.onPop(harness.instance)
+
+        assertTrue(trackingViewModel.isCleared)
+
+        // A composition racing teardown still holds the destination's owner;
+        // the strict holder lookup it performs must resolve the reseeded
+        // holder rather than throw.
+        val holder = destinationOwner.getNavigationHandleHolder()
+        assertEquals(harness.instance, holder.navigationHandle.instance)
+        assertEquals(Lifecycle.State.DESTROYED, holder.navigationHandle.lifecycle.currentState)
+    }
+
+    @Test
+    fun `clearing the parent store clears child ViewModels and reseeds a cleared NavigationHandle`() = runComposeUiTest {
+        val harness = composeDestination()
+        val destinationOwner = harness.destinationOwner
+        val trackingViewModel = harness.trackingViewModel
+
+        // Clearing the parent store clears ViewModelStoreStorage, which tears
+        // down every child destination store via onCleared — the path a parent
+        // destination's teardown takes while children are still composing.
+        harness.parentStore.clear()
+
+        assertTrue(trackingViewModel.isCleared)
+
+        val holder = destinationOwner.getNavigationHandleHolder()
+        assertEquals(harness.instance, holder.navigationHandle.instance)
+        assertEquals(Lifecycle.State.DESTROYED, holder.navigationHandle.lifecycle.currentState)
+    }
+
+    @Test
+    fun `a reseeded NavigationHandle ignores operations instead of crashing`() = runComposeUiTest {
+        val harness = composeDestination()
+        val destinationOwner = harness.destinationOwner
+
+        harness.parentStore.clear()
+
+        val holder = destinationOwner.getNavigationHandleHolder()
+        // The cleared handle must swallow operations (logging a warning)
+        // rather than executing or throwing.
+        holder.navigationHandle.execute(
+            NavigationOperation.Open(NavigationKeyFixtures.SimpleKey().asInstance()),
+        )
+    }
+}


### PR DESCRIPTION
## Context

We're seeing a production crash on iOS in an app on `3.0.0-beta03`:

```
Fatal Exception: kotlin.IllegalStateException
kfun:dev.enro.navigationHandle$$inlined$cache$1.invoke  (the viewModel initializer: "No NavigationHandle found for ...")
...
kfun:dev.enro#navigationHandle(...)
kfun:dev.enro.ui.NavigationDestination.Companion.NavigationDestination$Companion$create$1
...
ModalOverlayContent (a ModalBottomSheet-based overlay scene)
...
androidx.compose.ui.scene.ComposeSceneMediator#render / UIKitComposeSceneLayer
```

It's the same race #222 fixed for Dialog windows, surfacing through Material 3 `ModalBottomSheet` on iOS: the sheet's content composes in a separate UIKit compose scene layer with its own frame clock, so a destination's content can (re)compose for a frame after its `ViewModelStore` was cleared. Clearing the store itself schedules that doomed recomposition — `NavigationHandleHolder.onCleared` writes `ClearedNavigationHandle` into the `mutableStateOf` that `NavigationDestination.create`'s content lambda reads via `navigationHandle()`, and when the invalidated scope recomposes, the `viewModel<NavigationHandleHolder<T>>` lookup hits the cleared store and dies in the strict initializer.

## What this PR does

#222's reseed only runs on the direct pop path (`clearViewModelStoreForInstance`). `ViewModelStoreStorage.onCleared` — which fires when a **parent** destination's store is cleared while child destinations still exist — clears every child store *without* reseeding, so the same crash stays open for children (e.g. an open bottom sheet or dialog in a nested container) whose composition outlives the parent's teardown.

- Track the `NavigationKey.Instance` alongside each child store so `onCleared` can reseed too
- Share one `clearAndReseedNavigationHandle` helper between both clearing paths
- Add the Unreleased changelog entry covering this and #222 (the release workflow fails while the Unreleased section is empty, and we'd love a `3.0.0-beta04` with these fixes when you get a chance 🙏)
- Only wire `testWithEmulatorWtf` into `continuousIntegration` when `EW_API_TOKEN` is non-blank — fork PRs can't read repository secrets, so the token arrives empty and emulator.wtf fails the whole Linux job with `Http error 403: Invalid apiToken` (which is what failed CI on this PR). Pushes to main and same-repo PRs still run the device tests; fork PRs still run lint, host, desktop, and wasmJs tests.

## Testing

- Added `ViewModelStoreDecoratorTests` (commonTest, runs via `desktopTest`) covering both clearing paths through the decorator: the direct pop path from #222, the parent-store-clear path this PR fixes, and that a reseeded handle ignores operations instead of crashing. The parent-clear tests fail against `main`'s decorator and pass with this branch.
- `:enro-runtime:desktopTest` passes; `:enro-runtime:compileKotlinDesktop` and `:enro-runtime:compileKotlinIosSimulatorArm64` pass
- The full end-to-end race (a platform window/layer composition tearing down asynchronously) still isn't practically reproducible in a unit test, same as #222 — the new tests exercise the store-level behaviour that protects it

🤖 Generated with [Claude Code](https://claude.com/claude-code)