### PR TITLE
Reseed cleared NavigationHandleHolders when a parent's store storage is cleared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   operations), both when the destination itself is popped and when a parent destination's
   store is cleared while children are still composing.
 
+## 3.0.0-beta03 (2026-06-11)
+
 ### Web browser history (WasmJS)
 
 * Rewrote `WebHistoryPlugin`'s history synchronisation. Updates are now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 ## Unreleased
 
-## 3.0.0-beta03 (2026-06-11)
+### Stability
+
+* Fixed a production crash (`IllegalStateException: No NavigationHandle found for …` /
+  `Expected NavigationHandleHolder to be present in ViewModelStoreOwner …`) that occurred
+  when a destination's content composed or recomposed after its ViewModelStore had been
+  cleared. This race is possible because Dialog windows and (on iOS) ModalBottomSheet
+  layers compose their content in a separate composition that initializes and tears down
+  asynchronously from the composition that drives navigation. A destination's cleared
+  store is now reseeded with a no-op `NavigationHandle` (which logs and ignores
+  operations), both when the destination itself is popped and when a parent destination's
+  store is cleared while children are still composing.
 
 ### Web browser history (WasmJS)
 

--- a/buildSrc/src/main/kotlin/Project.configureEmulatorWtf.kt
+++ b/buildSrc/src/main/kotlin/Project.configureEmulatorWtf.kt
@@ -7,25 +7,20 @@ import java.io.FileInputStream
 import java.util.*
 
 fun Project.configureEmulatorWtf(numShards: Int = 2) {
+    val localProperties = Properties()
+    val localPropertiesFile = rootProject.file("local.properties")
+    if (localPropertiesFile.exists()) {
+        localProperties.load(FileInputStream(localPropertiesFile))
+    }
+
+    val apiToken: String? = when {
+        project.hasProperty("ewApiToken") -> project.properties["ewApiToken"].toString()
+        localProperties.hasProperty("ewApiToken") -> localProperties["ewApiToken"].toString()
+        else -> java.lang.System.getenv()["EW_API_TOKEN"]
+    }
+
     extensions.configure<EwExtension> {
-
-        val localProperties = Properties()
-        val localPropertiesFile = rootProject.file("local.properties")
-        if (localPropertiesFile.exists()) {
-            localProperties.load(FileInputStream(localPropertiesFile))
-        }
-
-        when {
-            project.hasProperty("ewApiToken") -> {
-                token.set(project.properties["ewApiToken"].toString())
-            }
-            localProperties.hasProperty("ewApiToken") -> {
-                token.set(localProperties["ewApiToken"].toString())
-            }
-            else -> {
-                token.set(java.lang.System.getenv()["EW_API_TOKEN"])
-            }
-        }
+        token.set(apiToken)
 
         this.numShards.set(numShards)
 
@@ -56,6 +51,27 @@ fun Project.configureEmulatorWtf(numShards: Int = 2) {
         device {
             model.set(DeviceModel.PIXEL_2)
             version.set(23)
+        }
+    }
+
+    // Without a token the emulator.wtf CLI fails the build with "Http error 403:
+    // Invalid apiToken". That is the normal state for pull_request CI runs from
+    // forks (GitHub withholds repository secrets from them) and for local
+    // checkouts without a token, so skip the device tests — loudly — rather than
+    // failing every other check in the same run. The test APKs still build, so the
+    // instrumented test sources are still compile-checked. Maintainers get a full
+    // device-test run by pushing the branch to this repository.
+    if (apiToken.isNullOrBlank()) {
+        tasks.matching { it.name.endsWith("WithEmulatorWtf") }.configureEach {
+            onlyIf("no emulator.wtf API token is configured") {
+                logger.warn(
+                    "Skipping $path: no emulator.wtf API token is configured " +
+                        "(set ewApiToken in local.properties, pass -PewApiToken, or set EW_API_TOKEN). " +
+                        "Device tests do not run for pull requests from forks because repository " +
+                        "secrets are unavailable to them; push the branch to this repository for a full run."
+                )
+                false
+            }
         }
     }
 }

--- a/enro-runtime/build.gradle.kts
+++ b/enro-runtime/build.gradle.kts
@@ -32,6 +32,7 @@ tasks.withType<org.gradle.api.tasks.testing.Test>().configureEach {
         filter {
             excludeTestsMatching("dev.enro.SceneHarnessSmokeTest")
             excludeTestsMatching("dev.enro.SceneIntegrationTests")
+            excludeTestsMatching("dev.enro.ClearedNavigationHandleReseedTests")
             excludeTestsMatching("dev.enro.BackstackSavedStateTests")
         }
     }

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/ui/decorators/navigationViewModelStoreDecorator.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/ui/decorators/navigationViewModelStoreDecorator.kt
@@ -165,33 +165,49 @@ private class DestinationViewModelStoreOwner(
  * This ViewModel is stored in the parent ViewModelStore and manages child stores.
  */
 private class ViewModelStoreStorage : ViewModel() {
-    private val stores = mutableMapOf<String, ViewModelStore>()
+    private val stores = mutableMapOf<String, StoreEntry>()
+
+    private class StoreEntry(
+        val instance: NavigationKey.Instance<*>,
+        val store: ViewModelStore,
+    )
 
     fun viewModelStoreForInstance(instance: NavigationKey.Instance<*>): ViewModelStore {
-        return stores.getOrPut(instance.id) { ViewModelStore() }
+        return stores.getOrPut(instance.id) { StoreEntry(instance, ViewModelStore()) }.store
     }
 
     fun clearViewModelStoreForInstance(instance: NavigationKey.Instance<*>) {
-        val store = stores.remove(instance.id) ?: return
-        store.clear()
-        // A destination's composition can outlive the pop that clears its ViewModelStore:
-        // a Dialog's content composes in a separate window composition that initializes
-        // asynchronously on window attach, so a destination popped in the same frame it was
-        // opened can still create ViewModels against this store. Reseed a cleared holder so
-        // that late creation receives a no-op NavigationHandle (which logs and ignores
-        // operations) instead of crashing the strict lookup in getNavigationHandleHolder.
-        ViewModelProvider.create(
-            store = store,
-            factory = viewModelFactory {
-                initializer { NavigationHandleHolder.cleared(instance) }
-            },
-        )[NavigationHandleHolder::class]
+        val entry = stores.remove(instance.id) ?: return
+        entry.store.clearAndReseedNavigationHandle(instance)
     }
 
     override fun onCleared() {
-        stores.forEach { (_, store) -> store.clear() }
+        stores.forEach { (_, entry) ->
+            entry.store.clearAndReseedNavigationHandle(entry.instance)
+        }
         stores.clear()
     }
+}
+
+/**
+ * A destination's composition can outlive the clear of its ViewModelStore:
+ * a Dialog's content (or a ModalBottomSheet's, on iOS) composes in a separate
+ * window/layer composition that initializes and tears down asynchronously, so a
+ * destination that is popped — or whose parent destination is popped, which clears
+ * every child store through [ViewModelStoreStorage.onCleared] — can still create
+ * ViewModels against this store for a frame. Reseed a cleared holder so that late
+ * creation receives a no-op NavigationHandle (which logs and ignores operations)
+ * instead of crashing the strict lookup in getNavigationHandleHolder or the
+ * `navigationHandle()` composable's "No NavigationHandle found" initializer.
+ */
+private fun ViewModelStore.clearAndReseedNavigationHandle(instance: NavigationKey.Instance<*>) {
+    clear()
+    ViewModelProvider.create(
+        store = this,
+        factory = viewModelFactory {
+            initializer { NavigationHandleHolder.cleared(instance) }
+        },
+    )[NavigationHandleHolder::class]
 }
 
 /**

--- a/enro-runtime/src/commonTest/kotlin/dev/enro/ClearedNavigationHandleReseedTests.kt
+++ b/enro-runtime/src/commonTest/kotlin/dev/enro/ClearedNavigationHandleReseedTests.kt
@@ -2,11 +2,13 @@ package dev.enro
 
 import androidx.compose.material3.Text
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithText
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.compose.currentStateAsState
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import dev.enro.controller.createNavigationModule
 import dev.enro.handle.getNavigationHandleHolder
@@ -60,7 +62,8 @@ class ClearedNavigationHandleReseedTests {
                             val handle = navigationHandle()
                             compositionCount++
                             lastHandle = handle
-                            Text("state: ${handle.lifecycle.currentState}")
+                            val lifecycleState by handle.lifecycle.currentStateAsState()
+                            Text("state: $lifecycleState")
                         }
                     )
                 }

--- a/enro-runtime/src/commonTest/kotlin/dev/enro/ClearedNavigationHandleReseedTests.kt
+++ b/enro-runtime/src/commonTest/kotlin/dev/enro/ClearedNavigationHandleReseedTests.kt
@@ -1,0 +1,168 @@
+package dev.enro
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import dev.enro.controller.createNavigationModule
+import dev.enro.handle.getNavigationHandleHolder
+import dev.enro.test.EnroTest
+import dev.enro.test.fixtures.NavigationContextFixtures
+import dev.enro.ui.LocalNavigationContext
+import dev.enro.ui.NavigationDisplay
+import dev.enro.ui.navigationDestination
+import dev.enro.ui.rememberNavigationContainer
+import kotlinx.serialization.Serializable
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Regression tests for the "destination composition outlives its ViewModelStore" race.
+ *
+ * On some platforms a destination's content composes in a separate composition
+ * (a Dialog window, or a ModalBottomSheet layer on iOS) that initialises and tears
+ * down asynchronously from the composition that drives navigation, so content can
+ * (re)compose — and call `navigationHandle()` / create ViewModels — for a frame after
+ * the destination's ViewModelStore has been cleared. The runtime handles this by
+ * reseeding a cleared store with a `NavigationHandleHolder` carrying a no-op cleared
+ * handle (see `clearAndReseedNavigationHandle`).
+ *
+ * The asynchronous window/layer composition itself can't be reproduced in
+ * `runComposeUiTest`, so these tests reproduce the two halves of the race
+ * deterministically:
+ *  - clearing a store while the content is still composed, so the recomposition
+ *    scheduled by `NavigationHandleHolder.onCleared` runs against the cleared store
+ *    (the `ViewModelStoreStorage.onCleared` path — a parent store being cleared);
+ *  - performing a late ViewModel lookup against a destination's store after the
+ *    destination was popped (the `clearViewModelStoreForInstance` path).
+ */
+@OptIn(ExperimentalTestApi::class)
+class ClearedNavigationHandleReseedTests {
+
+    @Test
+    fun `content that recomposes after its parent ViewModelStore is cleared receives a cleared NavigationHandle`() =
+        runEnroComposeTest {
+            var compositionCount = 0
+            var lastHandle: NavigationHandle<NavigationKey>? = null
+            EnroTest.getCurrentNavigationController().addModule(
+                createNavigationModule {
+                    destination<ReseedTestKey>(
+                        navigationDestination<ReseedTestKey> {
+                            // navigationHandle() reads the holder's mutableStateOf-backed handle, so
+                            // clearing the holder invalidates this scope and forces a recomposition
+                            // that looks the holder up again against the (now cleared) store.
+                            val handle = navigationHandle()
+                            compositionCount++
+                            lastHandle = handle
+                            Text("state: ${handle.lifecycle.currentState}")
+                        }
+                    )
+                }
+            )
+            val rootContext = NavigationContextFixtures.createRootContext()
+
+            setContent {
+                CompositionLocalProvider(
+                    LocalNavigationContext provides rootContext,
+                    // The ViewModelStore decorator keeps per-destination stores inside the
+                    // LocalViewModelStoreOwner's store; provide the root context's so the test
+                    // can clear it directly.
+                    LocalViewModelStoreOwner provides rootContext,
+                ) {
+                    val container = rememberNavigationContainer(
+                        backstack = backstackOf(ReseedTestKey.asInstance()),
+                    )
+                    NavigationDisplay(state = container)
+                }
+            }
+            waitForIdle()
+            val compositionsBeforeClear = compositionCount
+            assertTrue(compositionsBeforeClear > 0, "destination content should have composed")
+
+            // Clear the parent store while the destination is still composed. This clears
+            // every child destination store through ViewModelStoreStorage.onCleared and
+            // schedules a recomposition of the content above. Without reseeding, that
+            // recomposition throws "No NavigationHandle found for ...".
+            runOnUiThread { rootContext.viewModelStore.clear() }
+            waitForIdle()
+
+            assertTrue(
+                actual = compositionCount > compositionsBeforeClear,
+                message = "clearing the holder should have recomposed the destination content",
+            )
+            val handle = assertNotNull(lastHandle)
+            assertEquals(Lifecycle.State.DESTROYED, handle.lifecycle.currentState)
+            assertEquals(ReseedTestKey, handle.instance.key)
+            onNodeWithText("state: DESTROYED").assertIsDisplayed()
+
+            // Operations against the cleared handle are logged and ignored, never thrown.
+            handle.close()
+        }
+
+    @Test
+    fun `late NavigationHandleHolder lookup against a popped destination's store returns a cleared handle`() =
+        runEnroComposeTest {
+            var poppedDestinationOwner: ViewModelStoreOwner? = null
+            var poppedHandle: NavigationHandle<NavigationKey>? = null
+            EnroTest.getCurrentNavigationController().addModule(
+                createNavigationModule {
+                    destination<ReseedTestKey>(
+                        navigationDestination<ReseedTestKey> { Text("underlying") }
+                    )
+                    destination<ReseedTestChildKey>(
+                        navigationDestination<ReseedTestChildKey> {
+                            // navigationHandle() resolves the holder through LocalNavigationContext,
+                            // so this is the owner a late lookup in a racing composition would use.
+                            poppedDestinationOwner = LocalNavigationContext.current
+                            poppedHandle = navigationHandle()
+                            Text("popped destination")
+                        }
+                    )
+                }
+            )
+            val rootContext = NavigationContextFixtures.createRootContext()
+
+            setContent {
+                CompositionLocalProvider(
+                    LocalNavigationContext provides rootContext,
+                    LocalViewModelStoreOwner provides rootContext,
+                ) {
+                    val container = rememberNavigationContainer(
+                        backstack = backstackOf(
+                            ReseedTestKey.asInstance(),
+                            ReseedTestChildKey.asInstance(),
+                        ),
+                    )
+                    NavigationDisplay(state = container)
+                }
+            }
+            onNodeWithText("popped destination").assertIsDisplayed()
+            val owner = assertNotNull(poppedDestinationOwner)
+            val handle = assertNotNull(poppedHandle)
+
+            runOnUiThread { handle.close() }
+            waitForIdle()
+            onNodeWithText("underlying").assertIsDisplayed()
+            assertEquals(Lifecycle.State.DESTROYED, handle.lifecycle.currentState)
+
+            // Simulate a composition that outlived the pop creating its ViewModel late: the
+            // strict lookup must find the reseeded holder rather than throwing
+            // "Expected NavigationHandleHolder to be present in ViewModelStoreOwner ...".
+            val lateHolder = owner.getNavigationHandleHolder()
+            assertEquals(Lifecycle.State.DESTROYED, lateHolder.navigationHandle.lifecycle.currentState)
+            assertEquals(ReseedTestChildKey, lateHolder.navigationHandle.instance.key)
+            lateHolder.navigationHandle.close()
+        }
+}
+
+@Serializable
+internal data object ReseedTestKey : NavigationKey
+
+@Serializable
+internal data object ReseedTestChildKey : NavigationKey


### PR DESCRIPTION
Supersedes #223 by @dan-gamelocker — this branch carries their commit unchanged (bee9e213) plus regression tests and a CI fix so everything can merge together. Closes #223.

## Context (from #223)

A production crash on iOS on `3.0.0-beta03`:

```
Fatal Exception: kotlin.IllegalStateException
kfun:dev.enro.navigationHandle$$inlined$cache$1.invoke  (the viewModel initializer: "No NavigationHandle found for ...")
...
kfun:dev.enro#navigationHandle(...)
kfun:dev.enro.ui.NavigationDestination.Companion.NavigationDestination$Companion$create$1
...
ModalOverlayContent (a ModalBottomSheet-based overlay scene)
...
androidx.compose.ui.scene.ComposeSceneMediator#render / UIKitComposeSceneLayer
```

It's the same race #222 fixed for Dialog windows, surfacing through Material 3 `ModalBottomSheet` on iOS: the sheet's content composes in a separate UIKit compose scene layer with its own frame clock, so a destination's content can (re)compose for a frame after its `ViewModelStore` was cleared. Clearing the store itself schedules that doomed recomposition — `NavigationHandleHolder.onCleared` writes `ClearedNavigationHandle` into the `mutableStateOf` that `NavigationDestination.create`'s content lambda reads via `navigationHandle()`, and when the invalidated scope recomposes, the `viewModel<NavigationHandleHolder<T>>` lookup hits the cleared store and dies in the strict initializer.

## The fix (dan's commit)

#222's reseed only runs on the direct pop path (`clearViewModelStoreForInstance`). `ViewModelStoreStorage.onCleared` — which fires when a **parent** destination's store is cleared while child destinations still exist — cleared every child store *without* reseeding, so the same crash stayed open for children (e.g. an open bottom sheet or dialog in a nested container) whose composition outlives the parent's teardown.

- Track the `NavigationKey.Instance` alongside each child store so `onCleared` can reseed too
- Share one `clearAndReseedNavigationHandle` helper between both clearing paths
- Unreleased changelog entry covering this and #222

## Added on top

**Regression tests** — `ClearedNavigationHandleReseedTests` (commonTest, runs on desktop/iOS like the other Compose tests). The async window/layer composition can't be reproduced in `runComposeUiTest`, but both halves of the race can be, deterministically:

1. Clear the parent `ViewModelStore` while a destination whose content calls `navigationHandle()` is still composed. The holder clear invalidates the content scope, and the forced recomposition looks the holder up against the cleared child store — the exact production path. Fails on `main` with `No NavigationHandle found for dev.enro.NavigationKey`; passes with the fix.
2. Pop a destination, then perform the strict `getNavigationHandleHolder()` lookup against its captured context (a late ViewModel creation). Guards #222's path — fails with `Expected NavigationHandleHolder to be present…` if that reseed is removed.

**Changelog** — the entry in #223 had replaced the `## 3.0.0-beta03` heading, folding beta03's notes into Unreleased (and therefore into beta04's release notes); the heading is reinstated.

**CI** — #223's Linux job failed at `testAndroidMainWithEmulatorWtf` with `Http error 403: Invalid apiToken`: the PR came from a fork, and GitHub withholds repository secrets from fork `pull_request` runs, so `EW_API_TOKEN` was empty. `configureEmulatorWtf` now skips the `*WithEmulatorWtf` tasks with a warning when no token is resolvable (fork PRs, local checkouts without one) instead of failing the whole job; the device-test APK still builds so instrumented test sources stay compile-checked. Verified locally with `-PewApiToken=`: tasks `SKIPPED`, build successful.

## Testing

- `:enro-runtime:desktopTest` — 189 tests, 0 failures (includes the two new tests)
- Before/after matrix for the new tests: on `main` test 1 fails with the production crash and test 2 passes; with the fix both pass; with #222's reseed reverted only test 2 fails
- `:tests:application:common:testWithEmulatorWtf -PewApiToken=` → `SKIPPED`, `BUILD SUCCESSFUL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnDTWoaytfi2ggJ4FumfPd
