### PR TITLE
enro-test: common result-simulation API and small API fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+### enro-test
+
+* Added `sendResultForTest(result)`, `sendCompletedForTest()`, and
+  `sendClosedForTest()` extensions on `NavigationKey.Instance` in commonMain,
+  enabling ViewModel result-channel testing on all KMP targets.
+* Deprecated the Android-only `sendResultForTest` in
+  `dev.enro.test.extensions` in favour of the new common version.
+* Widened `assertClosed()` / `assertNotClosed()` receivers from
+  `TestNavigationHandle<NavigationKey>` to `TestNavigationHandle<*>`.
+* Deprecated `EnroTest.disableAnimations()` / `enableAnimations()` (no-ops
+  in the current API).
+* Added KDoc to `TestNavigationHandle`, `putNavigationHandleForViewModel`,
+  `assertOperationExecuted`, and `assertOperationNotExecuted`.
+
+### enro-runtime
+
+* Fixed `navigationHandle<K>()` KDoc: the delegate throws at construction
+  (ViewModel init), not on first access.
+
 ## 3.0.0-beta03 (2026-06-11)
 
 ### Web browser history (WasmJS)

--- a/docs/ghpages/docs/advanced/testing.md
+++ b/docs/ghpages/docs/advanced/testing.md
@@ -162,6 +162,41 @@ The injected handle survives until you put a new one for the same ViewModel
 type. Pair it with `runEnroTest` (or `EnroTestRule`) so the underlying
 controller is set up.
 
+### Simulating child results
+
+When a ViewModel opens a child destination through a `NavigationResultChannel`,
+use the `send*ForTest` extensions on the child's `NavigationKey.Instance`
+(returned by `assertOpened`) to simulate the child completing or closing:
+
+```kotlin
+// sendResultForTest — typed result
+val child = handle.assertOpened<ConfirmDestination>()
+child.sendResultForTest("confirmed")
+
+// sendCompletedForTest — Unit/no-payload completion
+val dialog = handle.assertOpened<AcknowledgeDialog>()
+dialog.sendCompletedForTest()
+
+// sendClosedForTest — the child was dismissed without a result
+val picker = handle.assertOpened<DatePicker>()
+picker.sendClosedForTest()
+```
+
+Result channels observe in `viewModelScope`, which dispatches on `Dispatchers.Main`.
+In tests, replace Main with an unconfined dispatcher so callbacks fire eagerly:
+
+```kotlin
+@BeforeTest
+fun setUp() {
+    Dispatchers.setMain(UnconfinedTestDispatcher())
+}
+
+@AfterTest
+fun tearDown() {
+    Dispatchers.resetMain()
+}
+```
+
 ## Strict mode
 
 When `runEnroTest { }` or `EnroTestRule` is active, attempting to perform

--- a/enro-runtime/build.gradle.kts
+++ b/enro-runtime/build.gradle.kts
@@ -59,6 +59,7 @@ kotlin {
         commonTest.dependencies {
             implementation(project(":enro-test"))
             implementation(libs.compose.uiTest)
+            implementation(libs.kotlinx.coroutines.test)
         }
         val androidHostTest by getting {
             dependencies {

--- a/enro-runtime/src/commonMain/kotlin/dev/enro/NavigationHandle.viewmodel.kt
+++ b/enro-runtime/src/commonMain/kotlin/dev/enro/NavigationHandle.viewmodel.kt
@@ -22,9 +22,10 @@ import kotlin.reflect.KClass
  * }
  * ```
  *
- * If [K] doesn't match the destination's actual key type, the property
- * throws on first access with a clear message — usually a sign the wrong
- * ViewModel was wired to the destination. Configuration registered via
+ * If [K] doesn't match the destination's actual key type, the delegate
+ * throws at construction (during ViewModel init) with a clear message —
+ * usually a sign the wrong ViewModel was wired to the destination.
+ * Configuration registered via
  * [config] is torn down when the ViewModel itself is cleared.
  */
 public inline fun <reified K : NavigationKey> ViewModel.navigationHandle(

--- a/enro-runtime/src/commonTest/kotlin/dev/enro/SendResultForTestTests.kt
+++ b/enro-runtime/src/commonTest/kotlin/dev/enro/SendResultForTestTests.kt
@@ -1,0 +1,148 @@
+@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package dev.enro
+
+import androidx.lifecycle.ViewModel
+import dev.enro.result.NavigationResultChannel
+import dev.enro.result.NavigationResultScope
+import dev.enro.result.open
+import dev.enro.result.registerForNavigationResult
+import dev.enro.test.assertOpened
+import dev.enro.test.putNavigationHandleForViewModel
+import dev.enro.test.runEnroTest
+import dev.enro.test.sendClosedForTest
+import dev.enro.test.sendCompletedForTest
+import dev.enro.test.sendResultForTest
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlinx.serialization.Serializable
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the `sendResultForTest`, `sendCompletedForTest`, and `sendClosedForTest`
+ * extensions on [NavigationKey.Instance].
+ *
+ * Each test constructs a ViewModel with a result channel, opens a child via that
+ * channel, then uses the send*ForTest helper on the child instance and asserts the
+ * ViewModel's callbacks. The Main dispatcher is replaced with [UnconfinedTestDispatcher]
+ * so that `viewModelScope` coroutines (used by [NavigationResultChannel.observe]) execute
+ * eagerly.
+ */
+class SendResultForTestTests {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+        NavigationResultChannel.pendingResults.value = emptyMap()
+    }
+
+    @Test
+    fun `sendResultForTest delivers typed result to ViewModel onCompleted callback`() = runEnroTest {
+        val handle = putNavigationHandleForViewModel<StringResultTestViewModel, ParentKey>(
+            ParentKey(),
+        )
+
+        val viewModel = StringResultTestViewModel()
+        viewModel.resultChannel.open(StringResultChildKey())
+
+        val child = handle.assertOpened<StringResultChildKey>()
+        child.sendResultForTest("hello")
+
+        assertEquals("hello", viewModel.receivedResult)
+        assertFalse(viewModel.closedCalled)
+    }
+
+    @Test
+    fun `sendCompletedForTest fires onCompleted for Unit result channel`() = runEnroTest {
+        val handle = putNavigationHandleForViewModel<UnitResultTestViewModel, ParentKey>(
+            ParentKey(),
+        )
+
+        val viewModel = UnitResultTestViewModel()
+        viewModel.resultChannel.open(UnitChildKey())
+
+        val child = handle.assertOpened<UnitChildKey>()
+        child.sendCompletedForTest()
+
+        assertTrue(viewModel.completedCalled)
+        assertFalse(viewModel.closedCalled)
+    }
+
+    @Test
+    fun `sendClosedForTest fires onClosed and not onCompleted`() = runEnroTest {
+        val handle = putNavigationHandleForViewModel<UnitResultTestViewModel, ParentKey>(
+            ParentKey(),
+        )
+
+        val viewModel = UnitResultTestViewModel()
+        viewModel.resultChannel.open(UnitChildKey())
+
+        val child = handle.assertOpened<UnitChildKey>()
+        child.sendClosedForTest()
+
+        assertTrue(viewModel.closedCalled)
+        assertFalse(viewModel.completedCalled)
+    }
+
+    @Test
+    fun `neither callback fires when no result is sent`() = runEnroTest {
+        putNavigationHandleForViewModel<StringResultTestViewModel, ParentKey>(
+            ParentKey(),
+        )
+
+        val viewModel = StringResultTestViewModel()
+
+        assertNull(viewModel.receivedResult)
+        assertFalse(viewModel.closedCalled)
+    }
+}
+
+@Serializable
+private data class ParentKey(val id: String = "parent") : NavigationKey
+
+@Serializable
+private data class StringResultChildKey(val id: String = "child") : NavigationKey.WithResult<String>
+
+@Serializable
+private data class UnitChildKey(val id: String = "child") : NavigationKey
+
+private class StringResultTestViewModel : ViewModel() {
+    val navigation by navigationHandle<ParentKey>()
+
+    var receivedResult: String? = null
+    var closedCalled = false
+
+    val resultChannel by registerForNavigationResult<String>(
+        onClosed = { closedCalled = true },
+        onCompleted = { result -> receivedResult = result },
+    )
+}
+
+private class UnitResultTestViewModel : ViewModel() {
+    val navigation by navigationHandle<ParentKey>()
+
+    var completedCalled = false
+    var closedCalled = false
+
+    val resultChannel by registerForNavigationResult(
+        onClosed = { closedCalled = true },
+        onCompleted = { completedCalled = true },
+    )
+}

--- a/enro-runtime/src/commonTest/kotlin/dev/enro/SendResultForTestTests.kt
+++ b/enro-runtime/src/commonTest/kotlin/dev/enro/SendResultForTestTests.kt
@@ -4,6 +4,7 @@
 package dev.enro
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dev.enro.result.NavigationResultChannel
 import dev.enro.result.NavigationResultScope
 import dev.enro.result.open
@@ -16,6 +17,7 @@ import dev.enro.test.sendCompletedForTest
 import dev.enro.test.sendResultForTest
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
@@ -41,6 +43,12 @@ import kotlin.test.assertTrue
 class SendResultForTestTests {
 
     private val testDispatcher = UnconfinedTestDispatcher()
+    private val createdViewModels = mutableListOf<ViewModel>()
+
+    private fun <T : ViewModel> T.track(): T {
+        createdViewModels += this
+        return this
+    }
 
     @BeforeTest
     fun setUp() {
@@ -49,8 +57,13 @@ class SendResultForTestTests {
 
     @AfterTest
     fun tearDown() {
-        Dispatchers.resetMain()
+        // Cancel the channels' observe collectors before resetting Main: a collector left
+        // subscribed to pendingResults would be woken by a later test's registerResult and
+        // dispatch to a Main dispatcher that no longer exists on targets without one.
+        createdViewModels.forEach { it.viewModelScope.cancel() }
+        createdViewModels.clear()
         NavigationResultChannel.pendingResults.value = emptyMap()
+        Dispatchers.resetMain()
     }
 
     @Test
@@ -59,7 +72,7 @@ class SendResultForTestTests {
             ParentKey(),
         )
 
-        val viewModel = StringResultTestViewModel()
+        val viewModel = StringResultTestViewModel().track()
         viewModel.resultChannel.open(StringResultChildKey())
 
         val child = handle.assertOpened<StringResultChildKey>()
@@ -75,7 +88,7 @@ class SendResultForTestTests {
             ParentKey(),
         )
 
-        val viewModel = UnitResultTestViewModel()
+        val viewModel = UnitResultTestViewModel().track()
         viewModel.resultChannel.open(UnitChildKey())
 
         val child = handle.assertOpened<UnitChildKey>()
@@ -91,7 +104,7 @@ class SendResultForTestTests {
             ParentKey(),
         )
 
-        val viewModel = UnitResultTestViewModel()
+        val viewModel = UnitResultTestViewModel().track()
         viewModel.resultChannel.open(UnitChildKey())
 
         val child = handle.assertOpened<UnitChildKey>()
@@ -107,7 +120,7 @@ class SendResultForTestTests {
             ParentKey(),
         )
 
-        val viewModel = StringResultTestViewModel()
+        val viewModel = StringResultTestViewModel().track()
 
         assertNull(viewModel.receivedResult)
         assertFalse(viewModel.closedCalled)

--- a/enro-test/src/androidMain/kotlin/dev/enro/test/compat/sendResultForTest.kt
+++ b/enro-test/src/androidMain/kotlin/dev/enro/test/compat/sendResultForTest.kt
@@ -4,6 +4,14 @@ import dev.enro.NavigationKey
 import dev.enro.asCompleteOperation
 import dev.enro.test.fixtures.NavigationContainerFixtures.ContainerFixtureKey
 
+@Deprecated(
+    message = "Use the common sendResultForTest from dev.enro.test instead",
+    level = DeprecationLevel.WARNING,
+    replaceWith = ReplaceWith(
+        "sendResultForTest(result)",
+        "dev.enro.test.sendResultForTest"
+    )
+)
 fun <T : Any> NavigationKey.Instance<NavigationKey.WithResult<T>>.sendResultForTest(
     result: T
 ) {

--- a/enro-test/src/commonMain/kotlin/dev/enro/test/EnroTest.kt
+++ b/enro-test/src/commonMain/kotlin/dev/enro/test/EnroTest.kt
@@ -50,13 +50,17 @@ object EnroTest {
         return navigationController ?: throw IllegalStateException("NavigationController is not installed")
     }
 
+    @Deprecated(
+        message = "This function is a no-op in the current API and will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     fun disableAnimations(controller: EnroController) {
-        // Animation control might need to be handled differently in the new API
-        // For now, we'll leave this as a no-op
     }
 
+    @Deprecated(
+        message = "This function is a no-op in the current API and will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     fun enableAnimations(controller: EnroController) {
-        // Animation control might need to be handled differently in the new API
-        // For now, we'll leave this as a no-op
     }
 }

--- a/enro-test/src/commonMain/kotlin/dev/enro/test/NavigationKeyInstance.sendResultForTest.kt
+++ b/enro-test/src/commonMain/kotlin/dev/enro/test/NavigationKeyInstance.sendResultForTest.kt
@@ -1,0 +1,77 @@
+@file:OptIn(AdvancedEnroApi::class)
+
+package dev.enro.test
+
+import dev.enro.NavigationKey
+import dev.enro.NavigationOperation
+import dev.enro.annotations.AdvancedEnroApi
+import dev.enro.asCompleteOperation
+import dev.enro.test.fixtures.NavigationContainerFixtures.ContainerFixtureKey
+
+/**
+ * Sends [result] back through the [NavigationKey.Instance]'s result channel,
+ * as though the destination completed with that value.
+ *
+ * Typically called on an instance returned by [assertOpened]:
+ * ```
+ * val child = handle.assertOpened<ConfirmDestination>()
+ * child.sendResultForTest("confirmed")
+ * ```
+ *
+ * When the instance was opened through a container fixture, the complete
+ * operation is routed through the fixture's interceptor pipeline. Otherwise,
+ * the result is registered directly on the pending-result channel.
+ */
+public fun <T : Any> NavigationKey.Instance<NavigationKey.WithResult<T>>.sendResultForTest(result: T) {
+    val containerFixture = metadata.get(ContainerFixtureKey)
+    val completeOperation = asCompleteOperation(result)
+    when (containerFixture) {
+        null -> completeOperation.registerResult()
+        else -> containerFixture.execute(completeOperation)
+    }
+}
+
+/**
+ * Sends a completion without a result payload through the
+ * [NavigationKey.Instance]'s result channel, firing any `onCompleted`
+ * callback registered via `registerForNavigationResult(onCompleted = { ... })`.
+ *
+ * Typically called on an instance returned by [assertOpened]:
+ * ```
+ * val child = handle.assertOpened<ConfirmDestination>()
+ * child.sendCompletedForTest()
+ * ```
+ *
+ * When the instance was opened through a container fixture, the complete
+ * operation is routed through the fixture's interceptor pipeline.
+ */
+public fun NavigationKey.Instance<*>.sendCompletedForTest() {
+    val containerFixture = metadata.get(ContainerFixtureKey)
+    val completeOperation = NavigationOperation.Complete(this)
+    when (containerFixture) {
+        null -> completeOperation.registerResult()
+        else -> containerFixture.execute(completeOperation)
+    }
+}
+
+/**
+ * Sends a close through the [NavigationKey.Instance]'s result channel,
+ * firing any `onClosed` callback registered via `registerForNavigationResult`.
+ *
+ * Typically called on an instance returned by [assertOpened]:
+ * ```
+ * val child = handle.assertOpened<ConfirmDestination>()
+ * child.sendClosedForTest()
+ * ```
+ *
+ * When the instance was opened through a container fixture, the close
+ * operation is routed through the fixture's interceptor pipeline.
+ */
+public fun NavigationKey.Instance<*>.sendClosedForTest() {
+    val containerFixture = metadata.get(ContainerFixtureKey)
+    val closeOperation = NavigationOperation.Close(this)
+    when (containerFixture) {
+        null -> closeOperation.registerResult()
+        else -> containerFixture.execute(closeOperation)
+    }
+}

--- a/enro-test/src/commonMain/kotlin/dev/enro/test/TestNavigationHandle.assertClosed.kt
+++ b/enro-test/src/commonMain/kotlin/dev/enro/test/TestNavigationHandle.assertClosed.kt
@@ -7,7 +7,7 @@ import dev.enro.NavigationOperation
 /**
  * Asserts that the NavigationHandle's instance has been closed
  */
-fun TestNavigationHandle<NavigationKey>.assertClosed() {
+fun TestNavigationHandle<*>.assertClosed() {
     val last = operations.lastOrNull()
     enroAssert(last != null) {
         "Expected the last operation to be a close operation, but there were no operations"
@@ -20,7 +20,7 @@ fun TestNavigationHandle<NavigationKey>.assertClosed() {
     }
 }
 
-fun TestNavigationHandle<NavigationKey>.assertNotClosed() {
+fun TestNavigationHandle<*>.assertNotClosed() {
     val last = operations.lastOrNull()
     if (last !is NavigationOperation.Close<*>) return
     enroAssert(last.instance.id != instance.id) {

--- a/enro-test/src/commonMain/kotlin/dev/enro/test/TestNavigationHandle.assertOperationExecuted.kt
+++ b/enro-test/src/commonMain/kotlin/dev/enro/test/TestNavigationHandle.assertOperationExecuted.kt
@@ -4,10 +4,10 @@ import dev.enro.NavigationKey
 import dev.enro.NavigationOperation
 
 /**
- * Asserts that the NavigationContainer's backstack contains at least one NavigationKey.Instance that matches the
- * provided predicate.
+ * Asserts that the [TestNavigationHandle]'s operation history contains at least one operation of type [T]
+ * matching the provided [predicate].
  *
- * @return The first NavigationKey.Instance that matches the predicate
+ * @return The last matching operation.
  */
 inline fun <reified T : NavigationOperation.RootOperation> TestNavigationHandle<*>.assertOperationExecuted(
     predicate: (T) -> Boolean = { true },
@@ -24,8 +24,8 @@ inline fun <reified T : NavigationOperation.RootOperation> TestNavigationHandle<
 }
 
 /**
- * Asserts that the NavigationContainer's backstack does not contain a NavigationKey.Instance that matches the provided
- * predicate
+ * Asserts that the [TestNavigationHandle]'s operation history does not contain an [Open] operation
+ * of type [T] matching the provided [predicate].
  */
 inline fun <reified T : NavigationKey> TestNavigationHandle<*>.assertOperationNotExecuted(
     predicate: (NavigationKey.Instance<T>) -> Boolean,

--- a/enro-test/src/commonMain/kotlin/dev/enro/test/TestNavigationHandle.kt
+++ b/enro-test/src/commonMain/kotlin/dev/enro/test/TestNavigationHandle.kt
@@ -10,6 +10,17 @@ import dev.enro.NavigationKey
 import dev.enro.NavigationOperation
 import dev.enro.asInstance
 
+/**
+ * A [NavigationHandle] implementation that records every [NavigationOperation] executed
+ * against it, instead of dispatching to a real navigation container.
+ *
+ * Recorded operations are stored in [operations] and can be inspected with the typed
+ * assertion helpers ([assertOpened], [assertClosed], [assertCompleted], etc.).
+ * Call [clearOperationHistory] to reset the list for a subsequent scenario.
+ *
+ * Once a [Close] or [Complete] targeting this handle's own [instance] has been recorded,
+ * the handle rejects further operations until [clearOperationHistory] is called.
+ */
 class TestNavigationHandle<out T : NavigationKey>(
     override val instance: NavigationKey.Instance<T>,
     override val savedStateHandle: SavedStateHandle = SavedStateHandle(),

--- a/enro-test/src/commonMain/kotlin/dev/enro/test/putNavigationHandleForViewModel.kt
+++ b/enro-test/src/commonMain/kotlin/dev/enro/test/putNavigationHandleForViewModel.kt
@@ -5,6 +5,14 @@ import dev.enro.NavigationKey
 import kotlin.reflect.KClass
 
 
+/**
+ * Registers a [TestNavigationHandle] for [key] so that when a [T] ViewModel is constructed,
+ * its `by navigationHandle<K>()` delegate (and any `registerForNavigationResult` channels)
+ * resolve against this handle.
+ *
+ * Must be called **before** constructing the ViewModel, because the `navigationHandle`
+ * delegate resolves eagerly at ViewModel init time via [NavigationHandleProvider].
+ */
 inline fun <reified T: ViewModel, K: NavigationKey> putNavigationHandleForViewModel(
     key: K,
 ) : TestNavigationHandle<K> {

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -79,6 +79,7 @@ kotlinx-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 
 thauvin-urlencoder = "net.thauvin.erik.urlencoder:urlencoder-lib:1.6.0"
 


### PR DESCRIPTION
## Summary

Closes the "inward" gap in enro-test: there was no common-code way to simulate a child destination delivering a result back into a `registerForNavigationResult` channel — the only helper was androidMain-only, `WithResult`-only, and unused.

- **New commonMain API** (`dev.enro.test`), chaining from `assertOpened<K>()`:
  - `NavigationKey.Instance<WithResult<T>>.sendResultForTest(result)` — typed completion
  - `NavigationKey.Instance<*>.sendCompletedForTest()` — Unit-channel completion (`registerForNavigationResult(onCompleted = {...})`)
  - `NavigationKey.Instance<*>.sendClosedForTest()` — fires `onClosed`
  All three route through a container fixture's interceptor pipeline when the instance was opened through one, and register directly on the pending-result channel otherwise. The old androidMain `sendResultForTest` is deprecated (WARNING) with `ReplaceWith`.
- **Fixes**: `assertClosed()`/`assertNotClosed()` receivers widened to `TestNavigationHandle<*>` (the class is covariant; the invariant receiver forced casts on typed handles); copy-pasted container KDoc on `assertOperationExecuted`/`assertOperationNotExecuted` rewritten; the `navigationHandle` delegate KDoc corrected ("throws on first access" → throws at construction, which is when resolution happens); `EnroTest.disableAnimations()`/`enableAnimations()` no-ops deprecated (WARNING); class-level KDoc for `TestNavigationHandle` and `putNavigationHandleForViewModel` (including the register-before-construction requirement).
- **Docs**: testing page documents the new API and the `Dispatchers.setMain` requirement for ViewModel result-channel tests (channels observe in `viewModelScope`); CHANGELOG entry added.

## Test plan

- New `SendResultForTestTests` (commonTest, run on desktop): typed result delivery, Unit completion, close firing `onClosed` and not `onCompleted`, and the nothing-sent negative — all against a bare `putNavigationHandleForViewModel` setup. 4/4 pass.
- Full `:enro-runtime:desktopTest` passes with no regressions; `:enro-test:compileKotlinDesktop` clean.

## Noted, not addressed

`runEnroTest` doesn't reset the global `NavigationResultChannel.pendingResults` registry — the new tests clear it manually in teardown via internal access. A result sent with no live observer would leak across tests; clearing it in `runEnroTest` teardown is a candidate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)