### PR TITLE
Bump AGP to 9.2.1 and compileSdk/targetSdk to 37

### DIFF
--- a/enro-runtime/src/androidHostTest/resources/robolectric.properties
+++ b/enro-runtime/src/androidHostTest/resources/robolectric.properties
@@ -1,0 +1,4 @@
+# Robolectric 4.16.1 emulates SDK levels up to 36, and the host-test manifest of a KMP library
+# takes its targetSdkVersion from compileSdk (37), which Robolectric rejects at initialisation.
+# Remove once Robolectric supports SDK 37.
+sdk=36

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
-# Pinned to 9.0.0 (not 9.2.0) so the project can be synced in IntelliJ IDEA, whose
-# bundled Android plugin currently supports AGP up to 9.0.0. The KMP-library DSL uses
-# the `androidLibrary {}` accessor, which is valid on 9.0–9.2, so this can be bumped
-# back to "9.2.0" once the IDE supports it (with only a deprecation warning).
-agp = "9.0.0"
-android-compileSdk = "36"
+# Must match the AGP version of every build that includes this one as a composite (ukpt,
+# udytils): Gradle refuses to load two AGP versions in one build. androidx Compose 1.12
+# (Compose Multiplatform 1.12) requires AGP 9.1.0+ and compileSdk 37. IntelliJ IDEA 2026.1
+# syncs AGP only up to 9.0.0; use Android Studio for Android work until the IDE catches up.
+agp = "9.2.1"
+android-compileSdk = "37"
 android-minSdk = "23"
-android-targetSdk = "36"
+android-targetSdk = "37"
 kotlin = "2.4.0"
 compose-plugin = "1.11.1"
 compose = "1.11.1"


### PR DESCRIPTION
Compose Multiplatform 1.12 maps to androidx Compose 1.12, whose AAR metadata requires AGP 9.1.0 and compileSdk 37. ukpt includes this build as a composite and Gradle refuses to load two AGP versions in one build, so the pin must match ukpt's (isaac-udy/ukpt#37). IntelliJ IDEA 2026.1 syncs AGP only up to 9.0.0; Android work needs Android Studio until it catches up.

Verified standalone: `:recipes:app:android` and `:tests:application:app:android` `checkDebugAarMetadata` (plus recipes `compileDebugKotlin`); and as part of ukpt's six-target sweep, Paparazzi and wasm bundle gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)